### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This is one of those "should have's" that most people aren't aware of (myself included until recently).

It comes up when creating a conda recipe that you have to ensure the license is included in the package. A `MANIFEST.in` does that (https://github.com/conda-forge/staged-recipes/pull/15282)