### PR TITLE
pixel_overlaps no longer changes the gdf_in outside of the function

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import xarray as xr
 import geopandas as gpd
+import copy
 from geopandas import testing as gpdt
 from unittest import TestCase
 from shapely.geometry import Polygon
@@ -12,6 +13,29 @@ from xagg.wrappers import (pixel_overlaps)
 
 
 ##### pixel_overlaps() tests #####
+def test_pixel_overlaps_nochange_gdf():
+	# To make sure the input gdf isn't changed by any processing
+	da = xr.DataArray(data=np.array([[0,1],[2,3]]),
+					  coords={'lat':(['lat'],np.array([0,1])),
+							'lon':(['lon'],np.array([0,1]))},
+					  dims=['lon','lat'])
+
+	# Create polygon covering one pixel
+	gdf_test = {'name':['test'],
+				'geometry':[Polygon([(-0.5,-0.5),(-0.5,0.5),(0.5,0.5),(0.5,-0.5),(-0.5,-0.5)])]}
+	gdf_test = gpd.GeoDataFrame(gdf_test,crs="EPSG:4326")
+
+	# Make deep copy to make sure the thing isn't changed
+	gdf_input = copy.deepcopy(gdf_test)
+
+	# Calculate pixel_overlaps through the wrapper function
+	wm = pixel_overlaps(da,gdf_test)
+
+	# See if gdf_test has changed
+	gpdt.assert_geodataframe_equal(gdf_test,gdf_input)
+
+
+
 def test_pixel_overlaps_dataarray():
 	# To make sure that pixel_overlaps works with an unnamed dataarray
 	da = xr.DataArray(data=np.array([[0,1],[2,3]]),

--- a/xagg/wrappers.py
+++ b/xagg/wrappers.py
@@ -1,5 +1,6 @@
 import warnings
 import xarray as xr
+import copy
 
 from . core import (create_raster_polygons,get_pixel_overlaps)
 
@@ -54,6 +55,9 @@ def pixel_overlaps(ds,gdf_in,
       input into :func:`xagg.core.aggregate`. 
     
     """
+    # Create deep copy of gdf to ensure the input gdf doesn't 
+    # get modified
+    gdf_in = copy.deepcopy(gdf_in)
 
     # Turn into dataset if dataarray
     if type(ds)==xr.core.dataarray.DataArray:


### PR DESCRIPTION
`copy.deepcopy()` is used to make sure the input gdf doesn't get modified by the function. (I would've thought that the function environment should prevent this from happening, but I was wrong, apparently).

Potential future memory issues may arise if very large gdfs are used.

A test was added to ensure future changes don't mess up this change.

Closes #21 . 