### PR TITLE
speed improvement for high res grids in create_raster_polygons

### DIFF
--- a/xagg/core.py
+++ b/xagg/core.py
@@ -156,7 +156,7 @@ def create_raster_polygons(ds,
             # in a way that the bounding box is fully filled out
             # bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1 
             grid_dist = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()]) # first get the max grid size
-            bbox_thresh = grid_dist*2, # then set threshold to twice grid size, avoids huge subsets for high res grids
+            bbox_thresh = grid_dist*2. # then set threshold to twice grid size, avoids huge subsets for high res grids
             ds = ds.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
                         lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
         else:

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -154,7 +154,9 @@ def create_raster_polygons(ds,
         if type(subset_bbox) == gpd.geodataframe.GeoDataFrame:
             # Using the biggest difference in lat/lon to make sure that the pixels are subset
             # in a way that the bounding box is fully filled out
-            bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1
+            # bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1 
+            grid_dist = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()]) # first get the max grid size
+            bbox_thresh = grid_dist*2, # then set threshold to twice grid size, avoids huge subsets for high res grids
             ds = ds.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
                         lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
         else:


### PR DESCRIPTION
Hi there, I'm a first timer when it comes to contributing to someone else's repo so please let me know if I need to fix/change anything. I've got a handful of small changes that greatly impact the speed of xagg when using high resolution grids. Planning to submit one at a time when I have the time to spend on it. It may take me a while...

This first one removes the hard coded 0.1 degree buffer for selecting a subset bounding box in create_raster_polygons. For high res grids this will select a much larger area than desired. The solution I propose is to change the 0.1 degree buffer to twice the max grid spacing.