### PR TITLE
Speedup for large grids - mod gdf_pixels in create_raster_polgons

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,21 +81,22 @@ def test_create_raster_polygons_basic():
 	# build raster polygons from a simple 2x2 grid of lat/lon pixels
 	ds = xr.Dataset({'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5]])),
 					 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5]]))},
-					coords={'lat':(['lat'],np.array([0,1])),
-							'lon':(['lon'],np.array([0,1])),
-							'bnds':(['bnds'],np.array([0,1]))})
+					coords={'lat':(['lat'],np.array([0.,1.])),
+							'lon':(['lon'],np.array([0.,1.])),
+							'bnds':(['bnds'],np.array([0.,1.]))})
 	pix_agg = create_raster_polygons(ds)
 
-	# Create comparison geodataframe (what it should come out to)
-	poly_test = {'lat':[np.array(v) for v in [0.,0.,1.,1.]],'lon':[np.array(v) for v in [0.,1.,0.,1.]],
+    # Create comparison geodataframe (what it should come out to)
+	poly_test = {'lat':np.array([0.,0.,1.,1.]),'lon':np.array([0.,1.,0.,1.]),
 						'geometry':[Polygon([(-0.5,-0.5),(-0.5,0.5),(0.5,0.5),(0.5,-0.5),(-0.5,-0.5)]),
 								   Polygon([(0.5, -0.5), (0.5, 0.5), (1.5, 0.5), (1.5, -0.5), (0.5, -0.5)]),
 								   Polygon([(-0.5, 0.5), (-0.5, 1.5), (0.5, 1.5), (0.5, 0.5), (-0.5, 0.5)]),
 								   Polygon([(0.5, 0.5), (0.5, 1.5), (1.5, 1.5), (1.5, 0.5), (0.5, 0.5)])],
 						'pix_idx':[0,1,2,3]}
+    
 	poly_test = gpd.GeoDataFrame(poly_test,crs="EPSG:4326")
 
-	# Use gpd assert (there's a check_less_precise option for "almost equal", 
+    # Use gpd assert (there's a check_less_precise option for "almost equal", 
 	# but that doesn't seem necessary for this simple example)
 	gpdt.assert_geodataframe_equal(poly_test,pix_agg['gdf_pixels'])
 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -156,7 +156,7 @@ def create_raster_polygons(ds,
             # in a way that the bounding box is fully filled out
             # bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1 
             grid_dist = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()]) # first get the max grid size
-            bbox_thresh = grid_dist*2, # then set threshold to twice grid size, avoids huge subsets for high res grids
+            bbox_thresh = grid_dist*2. # then set threshold to twice grid size, avoids huge subsets for high res grids
             ds = ds.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
                         lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
         else:

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -185,12 +185,13 @@ def create_raster_polygons(ds,
 #                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=0).values]))
     pix_poly_coords = np.transpose(np.vstack([ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=0).values,
                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values]))  
-    
+    print(pix_poly_coords)
     # Reshape so each location has a 4 x 2 (vertex vs coordinate) array, 
     # and convert each of those vertices to tuples. This means every element
     # of pix_poly_coords is the input to shapely.geometry.Polygon of one pixel
 #     pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
     pix_poly_coords = tuple(pix_poly_coords)    
+    print(pix_poly_coords)
     
     # Create empty geodataframe
     gdf_pixels = gpd.GeoDataFrame()
@@ -217,6 +218,7 @@ def create_raster_polygons(ds,
     # speed improvement for above loop
     poly_dict = {'poly_bnds': pix_poly_coords}
     df_poly = pd.DataFrame(poly_dict, columns=['poly_bnds'])
+    print(df_poly)
     df_poly['poly']=df_poly.poly_bnds.apply(lambda pts: Polygon.from_bounds(*pts))
     gdf_pixels['geometry']=df_poly['poly']
     gdf_pixels['lat']=ds_bnds.lat.values

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -175,8 +175,7 @@ def create_raster_polygons(ds,
                               drop_vars([v for v in ds.keys() if v not in ['lat_bnds','lon_bnds']])))
     # Stack so it's just pixels and bounds
     ds_bnds = ds_bnds.stack(loc=('lat','lon'))
-    
-    
+        
     # In order:
     # (lon0,lat0),(lon0,lat1),(lon1,lat1),(lon1,lat1), but as a single array; to be 
     # put in the right format for Polygon in the next step
@@ -184,20 +183,11 @@ def create_raster_polygons(ds,
                                                 ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=1).values,
                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values,
                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=0).values]))
-#     # In order:
-#     # polygon bounds [lon0, lat0, lon1, lat1] as a single array; to be put 
-#     # in the right format for Polygon.from_bounds in the next step
-#     pix_poly_coords = np.transpose(np.vstack([ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=0).values,
-#                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values]))  
 
     # Reshape so each location has a 4 x 2 (vertex vs coordinate) array, 
     # and convert each of those vertices to tuples. This means every element
     # of pix_poly_coords is the input to shapely.geometry.Polygon of one pixel
     pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
-#     # Reshape and covert to tuple so each element is a length 4 array of polygon 
-#     # bounds. This means every element of pix_poly_coords is the input to 
-#     # shapely.geometry.Polygon.from_bounds for one pixel
-#     pix_poly_coords = tuple(pix_poly_coords)    
     
     # Create empty geodataframe
     gdf_pixels = gpd.GeoDataFrame()
@@ -215,8 +205,7 @@ def create_raster_polygons(ds,
     # of that pixel 
     poly_dict = {'poly_bnds': pix_poly_coords}
     df_poly = pd.DataFrame(poly_dict, columns=['poly_bnds'])
-    print(df_poly)
-    df_poly['poly']=df_poly.poly_bnds.apply(lambda pts: Polygon(*pts))
+    df_poly['poly']=df_poly.poly_bnds.apply(lambda pts: Polygon(pts))
     gdf_pixels['geometry']=df_poly['poly']
     gdf_pixels['lat']=ds_bnds.lat.values
     gdf_pixels['lon']=ds_bnds.lon.values    

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -178,16 +178,19 @@ def create_raster_polygons(ds,
     
     # In order:
     # (lon0,lat0),(lon0,lat1),(lon1,lat1),(lon1,lat1), but as a single array; to be 
-    # put in the right format for Polygon in the next step
+    # put in the right format for Polygon.from_bounds in the next step
+#     pix_poly_coords = np.transpose(np.vstack([ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=0).values,
+#                                                 ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=1).values,
+#                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values,
+#                                                 ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=0).values]))
     pix_poly_coords = np.transpose(np.vstack([ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=0).values,
-                                                ds_bnds.lon_bnds.isel(bnds=0).values,ds_bnds.lat_bnds.isel(bnds=1).values,
-                                                ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values,
-                                                ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=0).values]))
+                                                ds_bnds.lon_bnds.isel(bnds=1).values,ds_bnds.lat_bnds.isel(bnds=1).values]))  
     
     # Reshape so each location has a 4 x 2 (vertex vs coordinate) array, 
     # and convert each of those vertices to tuples. This means every element
     # of pix_poly_coords is the input to shapely.geometry.Polygon of one pixel
-    pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
+#     pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
+    pix_poly_coords = tuple(pix_poly_coords)    
     
     # Create empty geodataframe
     gdf_pixels = gpd.GeoDataFrame()
@@ -204,12 +207,22 @@ def create_raster_polygons(ds,
     # Now populate with a polygon for every pixel, and the lat/lon coordinates
     # of that pixel (Try if preallocating it with the right dimensions above 
     # makes it faster, because it's pretty slow rn (NB: it doesn't really))
-    for loc_idx in np.arange(0,ds_bnds.dims['loc']):
-        gdf_pixels.loc[loc_idx,'lat'] = ds_bnds.lat.isel(loc=loc_idx).values
-        gdf_pixels.loc[loc_idx,'lon'] = ds_bnds.lon.isel(loc=loc_idx).values
-        gdf_pixels.loc[loc_idx,'geometry'] = Polygon(pix_poly_coords[loc_idx])
-        if weights is not None:
-            gdf_pixels.loc[loc_idx,'weights'] = weights.isel(loc=loc_idx).values
+#     for loc_idx in np.arange(0,ds_bnds.dims['loc']):
+#         gdf_pixels.loc[loc_idx,'lat'] = ds_bnds.lat.isel(loc=loc_idx).values
+#         gdf_pixels.loc[loc_idx,'lon'] = ds_bnds.lon.isel(loc=loc_idx).values
+#         gdf_pixels.loc[loc_idx,'geometry'] = Polygon(pix_poly_coords[loc_idx])
+#         if weights is not None:
+#             gdf_pixels.loc[loc_idx,'weights'] = weights.isel(loc=loc_idx).values
+
+    # speed improvement for above loop
+    poly_dict = {'poly_bnds': pix_poly_coords}
+    df_poly = pd.DataFrame(poly_dict, columns=['poly_bnds'])
+    df_poly['poly']=df_poly.poly_bnds.apply(lambda pts: Polygon.from_bounds(*pts))
+    gdf_pixels['geometry']=df_poly['poly']
+    gdf_pixels['lat']=ds_bnds.lat.values
+    gdf_pixels['lon']=ds_bnds.lon.values    
+    if weights is not None:
+        gdf_pixels['weights'] = weights.values # haven't tested this yet
         
     # Add a "pixel idx" to make indexing better later
     gdf_pixels['pix_idx'] = gdf_pixels.index.values

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -154,7 +154,9 @@ def create_raster_polygons(ds,
         if type(subset_bbox) == gpd.geodataframe.GeoDataFrame:
             # Using the biggest difference in lat/lon to make sure that the pixels are subset
             # in a way that the bounding box is fully filled out
-            bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1
+            # bbox_thresh = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()])+0.1 
+            grid_dist = np.max([ds.lat.diff('lat').max(),ds.lon.diff('lon').max()]) # first get the max grid size
+            bbox_thresh = grid_dist*2, # then set threshold to twice grid size, avoids huge subsets for high res grids
             ds = ds.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
                         lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
         else:

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -203,15 +203,15 @@ def create_raster_polygons(ds,
     
     # Now populate with a polygon for every pixel, and the lat/lon coordinates
     # of that pixel 
-    poly_dict = {'poly_bnds': pix_poly_coords}
-    df_poly = pd.DataFrame(poly_dict, columns=['poly_bnds'])
-    df_poly['poly']=df_poly.poly_bnds.apply(lambda pts: Polygon(pts))
+    poly_dict = {'poly_pts': pix_poly_coords}
+    df_poly = pd.DataFrame(poly_dict, columns=['poly_pts'])
+    df_poly['poly']=df_poly.poly_pts.apply(lambda pts: Polygon(pts))
     gdf_pixels['geometry']=df_poly['poly']
     gdf_pixels['lat']=ds_bnds.lat.values
-    gdf_pixels['lon']=ds_bnds.lon.values    
+    gdf_pixels['lon']=ds_bnds.lon.values  
     if weights is not None:
         gdf_pixels['weights'] = weights.values
-        
+
     # Add a "pixel idx" to make indexing better later
     gdf_pixels['pix_idx'] = gdf_pixels.index.values
     


### PR DESCRIPTION
In create_raster_polygons, the for loop that assigns individual polygons to gdf_pixels essentially renders xagg unusable for larger high res grids because it goes so slow. Here I propose elimination of the for loop and replacement with a lambda apply. Big improvement for large grids!