### PR TITLE
implement making dot product optional, restoring default agg behavior

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -326,8 +326,6 @@ def test_get_pixel_overlaps_gdf_wpreexisting_index(pix_agg=pix_agg):
 
 
 ##### aggregate() tests #####
-
-
 def test_aggregate_basic(ds=ds):
 	# Create polygon covering multiple pixels
 	gdf = {'name':['test'],
@@ -344,6 +342,29 @@ def test_aggregate_basic(ds=ds):
 
 	# Get aggregate
 	agg = aggregate(ds,wm)
+
+	# This requires shifting rtol to 1e-4 for some reason, in that 
+	# it's actually 1.499981, whereas multiplying out 
+	# np.sum(agg.agg.rel_area[0]*np.array([0,1,2,3]))gives 1.499963... 
+	# Possibly worth examining more closely later
+	assert np.allclose([v for v in agg.agg.test.values],1.4999,rtol=1e-4)
+
+def test_aggregate_basic_wdotproduct(ds=ds):
+	# Create polygon covering multiple pixels, using the dot product option
+	gdf = {'name':['test'],
+				'geometry':[Polygon([(0,0),(0,1),(1,1),(1,0),(0,0)])]}
+	gdf = gpd.GeoDataFrame(gdf,crs="EPSG:4326")
+
+	# calculate the pix_agg variable tested above, to be used in the 
+	# tests below
+	pix_agg = create_raster_polygons(ds)
+
+
+	# Get pixel overlaps
+	wm = get_pixel_overlaps(gdf,pix_agg,impl='dot_product')
+
+	# Get aggregate
+	agg = aggregate(ds,wm,impl='dot_product')
 
 	# This requires shifting rtol to 1e-4 for some reason, in that 
 	# it's actually 1.499981, whereas multiplying out 

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -24,7 +24,7 @@ class weightmap(object):
     """ Class for mapping from pixels to polgyons, output from :func:`xagg.wrappers.pixel_overlaps`
     
     """
-    def __init__(self,agg,source_grid,geometry,overlap_da,weights='nowghts'):
+    def __init__(self,agg,source_grid,geometry,overlap_da=None,weights='nowghts'):
         self.agg = agg
         self.source_grid = source_grid
         self.geometry = geometry

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -6,7 +6,7 @@ from shapely.geometry import Polygon
 import warnings
 import xesmf as xe
 
-from . aux import (find_rel_area,fix_ds,get_bnds,subset_find,list_or_first)
+from . aux import (find_rel_area,normalize,fix_ds,get_bnds,subset_find,list_or_first)
 from . classes import (weightmap,aggregated)
 
 
@@ -227,7 +227,7 @@ def create_raster_polygons(ds,
     return pix_agg
 
 
-def get_pixel_overlaps(gdf_in,pix_agg):
+def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
     """ Get, for each polygon, the pixels that overlap and their area of overlap
     
     Finds, for each polygon in `gdf_in`, which pixels intersect it, and by how much. 
@@ -254,6 +254,12 @@ def get_pixel_overlaps(gdf_in,pix_agg):
         - ``'source_grid'``
             ``[da.lat,da.lon]`` of the grid used to create
             the pixel polygons
+    impl : str
+        whether the output will be used for the dot-product aggregation 
+        calculation (needs a slightly different format), either of: 
+        - ``'for_loop'`` (default behavior)
+        - ``'dot_product'`` (to set up for ``impl='dot_product'`` in 
+            ``xagg.core.aggregate``)
     
 
     Returns
@@ -310,16 +316,28 @@ def get_pixel_overlaps(gdf_in,pix_agg):
                            pix_agg['gdf_pixels'].to_crs(epsg_set),
                            how='intersection')
     
-    overlaps = overlaps.groupby('poly_idx').apply(find_rel_area)
-    overlaps['lat'] = overlaps['lat'].astype(float)
-    overlaps['lon'] = overlaps['lon'].astype(float)
+    if impl=='dot_product':
+        overlaps = overlaps.groupby('poly_idx').apply(find_rel_area)
+        overlaps['lat'] = overlaps['lat'].astype(float)
+        overlaps['lon'] = overlaps['lon'].astype(float)
 
-    # Now, group by poly_idx (each polygon in the shapefile)
-    ov_groups = overlaps.groupby('poly_idx')
+        # Now, group by poly_idx (each polygon in the shapefile)
+        ov_groups = overlaps.groupby('poly_idx')
 
-    overlap_info = ov_groups.agg(list_or_first)
+        overlap_info = ov_groups.agg(list_or_first)
 
-    overlap_info = overlap_info.rename(columns={'pix_idx': 'pix_idxs'})
+        overlap_info = overlap_info.rename(columns={'pix_idx': 'pix_idxs'})
+    elif impl=='for_loop':
+        # Now, group by poly_idx (each polygon in the shapefile)
+        ov_groups = overlaps.groupby('poly_idx')
+        # Calculate relative area of each overlap (so how much of the total 
+        # area of each polygon is taken up by each pixel), the pixels 
+        # corresponding to those areas, and the lat/lon coordinates of 
+        # those pixels
+        overlap_info = ov_groups.agg(rel_area=pd.NamedAgg(column='geometry',aggfunc=lambda ds: [normalize(ds.area)]),
+                                       pix_idxs=pd.NamedAgg(column='pix_idx',aggfunc=lambda ds: [idx for idx in ds]),
+                                       lat=pd.NamedAgg(column='lat',aggfunc=lambda ds: [x for x in ds]),
+                                       lon=pd.NamedAgg(column='lon',aggfunc=lambda ds: [x for x in ds]))
 
     # Zip lat, lon columns into a list of (lat,lon) coordinates
     # (separate from above because as of 12/20, named aggs with 
@@ -330,19 +348,28 @@ def get_pixel_overlaps(gdf_in,pix_agg):
     # Reset index to make poly_idx a column for merging with gdf_in
     overlap_info = overlap_info.reset_index()
 
-    # Merge in pixel overlaps to the input polygon geodataframe
-    overlap_columns = ['pix_idxs', 'rel_area', 'coords', 'poly_idx']
-    gdf_in = pd.merge(gdf_in, overlap_info[overlap_columns],'outer', on='poly_idx')
+    if impl=='dot_product':
+        # Merge in pixel overlaps to the input polygon geodataframe
+        overlap_columns = ['pix_idxs', 'rel_area', 'coords', 'poly_idx']
+        gdf_in = pd.merge(gdf_in, overlap_info[overlap_columns],'outer', on='poly_idx')
 
-    # make the weight grid an xarray dataset for later dot product
-    idx_cols = ['lat', 'lon', 'poly_idx']
-    overlap_da = overlaps.set_index(idx_cols)['rel_area'].to_xarray()
-    overlap_da = overlap_da.stack(loc=['lat', 'lon'])
-    overlap_da = overlap_da.fillna(0)
-    wm_out = weightmap(agg=gdf_in.drop('geometry', axis=1),
-               source_grid=pix_agg['source_grid'],
-               geometry=gdf_in.geometry,
-               overlap_da = overlap_da)
+        # make the weight grid an xarray dataset for later dot product
+        idx_cols = ['lat', 'lon', 'poly_idx']
+        overlap_da = overlaps.set_index(idx_cols)['rel_area'].to_xarray()
+        overlap_da = overlap_da.stack(loc=['lat', 'lon'])
+        overlap_da = overlap_da.fillna(0)
+        wm_out = weightmap(agg=gdf_in.drop('geometry', axis=1),
+                   source_grid=pix_agg['source_grid'],
+                   geometry=gdf_in.geometry,
+                   overlap_da = overlap_da)
+    elif impl=='for_loop':
+        # Merge in pixel overlaps to the input polygon geodataframe
+        gdf_in = pd.merge(gdf_in,overlap_info,'outer')
+
+        # Drop 'geometry' eventually, just for size/clarity
+        wm_out = weightmap(agg=gdf_in.drop('geometry',axis=1),
+                           source_grid=pix_agg['source_grid'],
+                           geometry=gdf_in.geometry)
     
     if 'weights' in pix_agg['gdf_pixels'].columns:
         wm_out.weights = pix_agg['gdf_pixels'].weights
@@ -350,7 +377,7 @@ def get_pixel_overlaps(gdf_in,pix_agg):
     return wm_out
 
 
-def aggregate(ds,wm):
+def aggregate(ds,wm,impl='for_loop'):
     """ Aggregate raster variable(s) to polygon(s)
     
     Aggregates (N-D) raster variables in `ds` to the polygons
@@ -391,6 +418,17 @@ def aggregate(ds,wm):
             the lat/lon grid on which the aggregating parameters
             were calculated (and on which the linear indices 
             are based)
+
+    impl : :class:str (def: ``'for_loop'``)
+        which aggregation calculation method to use, either of: 
+
+        - ``'for_loop'`` 
+            default behavior, aggregation loops through
+            all polygons in a for loop, requires less memory 
+        - ``'dot_product'`` 
+            aggregation is calculated using a dot product, 
+            requires much more memory (due to broadcasting of
+            variables) but may be faster in certain circumstances
                
     Returns
     ---------------
@@ -398,6 +436,11 @@ def aggregate(ds,wm):
         an :class:`xagg.classes.aggregated` object with the aggregated variables 
     
     """
+    # Make sure pixel_overlaps was correctly run if using dot product
+    if (impl=='dot_product') and (wm.overlap_da is None):
+        raise ValueError("no 'overlap_da' was found in the `wm` input - since you're using the dot product implementation, "+
+                         "make sure to run `pixel_overlaps()` with `impl='dot_product'` to avoid this error.")
+
     # Turn into dataset if dataarray
     if type(ds)==xr.core.dataarray.DataArray:
       if ds.name is None:
@@ -425,57 +468,120 @@ def aggregate(ds,wm):
             warnings.warn('wm.weights is: \n '+print(wm.weights)+
                             ', \n which is not a supported weight vector (in a pandas series) '+
                             'or "nowghts" as a string. Assuming no weights are included...')
-        weights = np.ones((len(wm.overlap_da['loc'])))
+        if impl=='dot_product':
+            weights = np.ones((len(wm.overlap_da['loc'])))
+        elif impl=='for_loop':
+            weights = np.ones((len(wm.source_grid['lat'])))
     
-    data_dict = dict()
-    for var in ds.var():
-        # Process for every variable that has locational information, but isn't a 
-        # bound variable
-        if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
-            print('aggregating '+var+'...')
+    if impl=='dot_product':
+        data_dict = dict()
+        for var in ds.var():
+            # Process for every variable that has locational information, but isn't a 
+            # bound variable
+            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+                print('aggregating '+var+'...')
 
-            # select just data for which we have overlaps
-            var_array = ds[var].sel(loc=wm.overlap_da['loc'])
+                # select just data for which we have overlaps
+                var_array = ds[var].sel(loc=wm.overlap_da['loc'])
 
-            # multiply percent-overlaps by user-supplied weights 
-            weights_and_overlaps = wm.overlap_da * weights
+                # multiply percent-overlaps by user-supplied weights 
+                weights_and_overlaps = wm.overlap_da * weights
 
-            # fill any nans in the gridded data to zero and change the corresponding
-            # weights to zero so that they will not affect the aggregated value
-            var_array_filled = var_array.fillna(0)
-            weights_and_overlaps = weights_and_overlaps.where(var_array.notnull(), 0)
+                # fill any nans in the gridded data to zero and change the corresponding
+                # weights to zero so that they will not affect the aggregated value
+                var_array_filled = var_array.fillna(0)
+                weights_and_overlaps = weights_and_overlaps.where(var_array.notnull(), 0)
 
-            # the weights now may add up to less than one because of nans or
-            # because of the user-supplied weights. here we normalize the
-            # weights so they add up to 1 and fill any nan's with 0 so they
-            # won't be counted
-            normed_weights = weights_and_overlaps/weights_and_overlaps.sum(dim = "loc", skipna=True)
-            normed_weights = normed_weights.fillna(0)
+                # the weights now may add up to less than one because of nans or
+                # because of the user-supplied weights. here we normalize the
+                # weights so they add up to 1 and fill any nan's with 0 so they
+                # won't be counted
+                normed_weights = weights_and_overlaps/weights_and_overlaps.sum(dim = "loc", skipna=True)
+                normed_weights = normed_weights.fillna(0)
 
-            # finally we do the dot product to get the weighted averages
-            aggregated_array = normed_weights.dot(var_array_filled)
+                # finally we do the dot product to get the weighted averages
+                aggregated_array = normed_weights.dot(var_array_filled)
 
-            # if the original gridded values were all nan, make the final
-            # aggregation nan
-            if np.isnan(var_array.values).all():
-                aggregated_array = aggregated_array * np.nan
+                # if the original gridded values were all nan, make the final
+                # aggregation nan
+                if np.isnan(var_array.values).all():
+                    aggregated_array = aggregated_array * np.nan
 
-            data_dict[var] = aggregated_array
+                data_dict[var] = aggregated_array
 
-    ds_combined = xr.Dataset(data_dict)    
-    df_combined = ds_combined.to_dataframe().reset_index()
-    df_combined = df_combined.groupby('poly_idx').agg(list_or_first)
+        ds_combined = xr.Dataset(data_dict)    
+        df_combined = ds_combined.to_dataframe().reset_index()
+        df_combined = df_combined.groupby('poly_idx').agg(list_or_first)
 
-    wm.agg = pd.merge(wm.agg, df_combined, on='poly_idx')
-    for var in ds.var():
-        if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
-            # convert to list of arrays - NOT SURE THIS IS THE RIGHT THING TO
-            # DO, JUST TRYING TO MATCH ORIGINAL FORMAT
-            wm.agg[var] = wm.agg[var].apply(np.array).apply(lambda x: [x])
+        wm.agg = pd.merge(wm.agg, df_combined, on='poly_idx')
+        for var in ds.var():
+            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+                # convert to list of arrays - NOT SURE THIS IS THE RIGHT THING TO
+                # DO, JUST TRYING TO MATCH ORIGINAL FORMAT
+                wm.agg[var] = wm.agg[var].apply(np.array).apply(lambda x: [x])
 
-    # Put in class format
-    agg_out = aggregated(agg=wm.agg,source_grid=wm.source_grid,
-    					 geometry=wm.geometry,ds_in=ds_combined,weights=wm.weights)
+        # Put in class format
+        agg_out = aggregated(agg=wm.agg,source_grid=wm.source_grid,
+                            geometry=wm.geometry,ds_in=ds_combined,weights=wm.weights)
+    elif impl=='for_loop':
+        for var in ds.var():
+            # Process for every variable that has locational information, but isn't a 
+            # bound variable
+            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+                print('aggregating '+var+'...')
+                # Create the column for the relevant variable
+                wm.agg[var] = None
+                
+                # Get weighted average of variable based on pixel overlap + other weights
+                for poly_idx in wm.agg.poly_idx:
+                    # Get average value of variable over the polygon; weighted by 
+                    # how much of the pixel area is in the polygon, and by (optionally)
+                    # a separate gridded weight. This if statement checks 
+                    # - if the weights output for this polygon is just "np.nan", which 
+                    #   indicates there's no overlap between the pixel grid and polygons
+                    # - [this has been pushed down a few lines] or, if all the pixels in 
+                    #   the grid have just nan values for this variable
+                    # in both cases; the "aggregated variable" is just a vector of nans. 
+                    if not np.isnan(wm.agg.iloc[poly_idx,:].pix_idxs).all():
+                        # Get the dimensions of the variable that aren't "loc" (location)
+                        other_dims = [k for k in np.atleast_1d(ds[var].dims) if k != 'loc']
+                        # Check first if any nans are "complete" (meaning that a pixel 
+                        # either has values for each step, or nans for each step - if
+                        # there are random nans within a pixel, throw a warning)
+                        if not xr.Dataset.equals(np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).any(other_dims),
+                                                  np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).all(other_dims)):
+                            warnings.warn('One or more of the pixels in variable '+var+' have nans in them in the dimensions '+
+                                           ', '.join([k for k in ds[var].dims if k != 'loc'])+
+                                           '. The code can currently only deal with pixels for which the '+
+                                           '*entire* pixel has nan values in all dimensions, however there is currently no '+
+                                           ' support for data in which pixels have only some nan values. The aggregation '+
+                                           'calculation is likely incorrect.')
+
+                        if not np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).all(): 
+                            # Get relative areas for the pixels overlapping with this Polygon
+                            tmp_areas = np.atleast_1d(np.squeeze(wm.agg.iloc[poly_idx,:].rel_area))
+                            # Replace overlapping pixel areas with nans if the corresponding pixel
+                            # is only composed of nans
+                            tmp_areas[np.array(np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).all(other_dims).values)] = np.nan
+                            # Calculate the normalized area+weight of each pixel (taking into account
+                            # nans)
+                            normed_areaweights = normalize(tmp_areas*weights[wm.agg.iloc[poly_idx,:].pix_idxs],drop_na=True)
+
+                            # Take the weighted average of all the pixel values to calculate the 
+                            # aggregated value for the shapefile
+                            wm.agg.loc[poly_idx,var] = [[((ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)*
+                                                             normed_areaweights).
+                                                            sum('loc')).values]]
+
+                        else:
+                            wm.agg.loc[poly_idx,var] = [[(ds[var].isel(loc=0)*np.nan).values]]
+
+                    else:
+                        wm.agg.loc[poly_idx,var] = [[(ds[var].isel(loc=0)*np.nan).values]]
+
+        # Put in class format
+        agg_out = aggregated(agg=wm.agg,source_grid=wm.source_grid,
+        					 geometry=wm.geometry,ds_in=ds,weights=wm.weights)
 
     # Return
     print('all variables aggregated to polygons!')

--- a/xagg/wrappers.py
+++ b/xagg/wrappers.py
@@ -7,7 +7,8 @@ from . core import (create_raster_polygons,get_pixel_overlaps)
 
 def pixel_overlaps(ds,gdf_in,
                    weights=None,weights_target='ds',
-                   subset_bbox = True):
+                   subset_bbox = True,
+                   impl='for_loop'):
     """ Wrapper function for determining overlaps between grid and polygon
     
     For a geodataframe `gdf_in`, takes an `xarray` structure `ds` (Dataset or 
@@ -41,11 +42,16 @@ def pixel_overlaps(ds,gdf_in,
       be on the same grid as `ds` - grids will be homogonized
       (see below).
 
-    weights_target : str, optional
+    weights_target : :class:`str`, optional
       if 'ds', then weights are regridded to the grid in [ds];
       if 'weights', then the `ds` variables are regridded to
       the grid in 'weights' (LATTER NOT SUPPORTED YET, raises
       a `NotImplementedError`)
+
+    impl : :class:`str`, optional, default = ``'for_loop'``
+      whether to use the ``'for_loop'`` or ``'dot_product'``
+      methods for aggregating; the former uses less memory,
+      the latter may be faster in certain circumstances
    
     
     Returns
@@ -75,7 +81,7 @@ def pixel_overlaps(ds,gdf_in,
     
     # Get overlaps between these pixel polygons and the gdf_in polygons
     print('calculating overlaps between pixels and output polygons...')
-    wm_out = get_pixel_overlaps(gdf_in,pix_agg)
+    wm_out = get_pixel_overlaps(gdf_in,pix_agg,impl=impl)
     print('success!')
     
     return wm_out


### PR DESCRIPTION
The dot product implementation broke some workflows and isn't faster in every instance. The default behavior (aggregating data through a for loop over polgyons) is restored, with the dot product implementation accessible through an optional ``impl='dot_product'`` argument.

One test has been added to make sure the dot_product works in the basic aggregation case, but only one test has been changed. This may cause downstream issues in the future - therefore, recommend either
- fully integrating the dot product as a possibility into the workflow (this would require additionally making every relevant test also be run on the dot product implementation, in addition to lots of code cleanup - there are some redundancies right now due to the tacked on nature of this fix)
- revisiting under which circumstances the dot product implementation gives a substantial speed boost. If that is only the case in very limited circumstances, then perhaps it should be removed entirely.