### PR TITLE
Implement a way to save weightmaps (output from `pixel_overlaps`) 

### DIFF
--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -15,13 +15,11 @@ dependencies:
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
-  - matplotlib
-  - cartopy
-  - cmocean
+  - pytables
   ##############
   - pytest
   - pip:
     - codecov
     - pytest-cov
     - coverage[toml]
-    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)
+    #- tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -24,3 +24,4 @@ dependencies:
     - codecov
     - pytest-cov
     - coverage[toml]
+    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -24,3 +24,4 @@ dependencies:
     - codecov
     - pytest-cov
     - coverage[toml]
+    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -15,13 +15,11 @@ dependencies:
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
-  - matplotlib
-  - cartopy
-  - cmocean
+  - pytables
   ##############
   - pytest
   - pip:
     - codecov
     - pytest-cov
     - coverage[toml]
-    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)
+   # - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,5 @@ dependencies:
   - shapely
   - xesmf >= 0.5.2
   - cf_xarray # separately, to ensure latest version
+  - pip:
+    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/environment.yml
+++ b/environment.yml
@@ -3,20 +3,12 @@ channels:
   - conda-forge
 dependencies:
   - pytest
-  - jupyter
-  - jupyterlab
   - xarray
   - numpy
   - scipy
-  - dask
   - netcdf4
   - pandas
   - geopandas
-  - matplotlib
-  - cartopy
-  - cmocean
-  - shapely
   - xesmf >= 0.5.2
   - cf_xarray # separately, to ensure latest version
-  - pip:
-    - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)
+  - pytables

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
         'shapely',
         'xesmf>=0.5.2',
         'cf_xarray>=0.5.1',
-        'esmpy>=8.1.0' 
+        'esmpy>=8.1.0',
     ],
 )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -33,7 +33,7 @@ def test_pixel_overlaps_export_and_import():
 						'bnds':(['bnds'],np.array([0,1]))})
 
 	# Add a simple weights grid
-	weights = xr.DataArray(data=np.array([[0.,1.],[2.,3.]]),
+	weights = xr.DataArray(data=np.array([[0.,1.],[2.,3.]]).astype(object),
 								dims=['lat','lon'],
 								coords=[ds.lat,ds.lon])
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -33,7 +33,7 @@ def test_pixel_overlaps_export_and_import():
 						'bnds':(['bnds'],np.array([0,1]))})
 
 	# Add a simple weights grid
-	weights = xr.DataArray(data=np.array([[0,1],[2,3]]),
+	weights = xr.DataArray(data=np.array([[0.,1.],[2.,3.]]),
 								dims=['lat','lon'],
 								coords=[ds.lat,ds.lon])
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,82 @@
+import pytest
+import pandas as pd
+import numpy as np
+import xarray as xr
+import shutil
+import geopandas as gpd
+from geopandas import testing as gpdt
+from unittest import TestCase
+from shapely.geometry import Polygon
+
+from xagg.core import (process_weights,create_raster_polygons,get_pixel_overlaps,aggregate,read_wm)
+from xagg.wrappers import (pixel_overlaps)
+
+##### pixel_overlaps() export tests #####
+
+def test_pixel_overlaps_export_and_import():
+	# Testing the .to_file() --> read_wm() workflow. 
+	# Rather complex because of the many different components of wm. 
+	# wm.agg in particular is a dataframe with lists in it (which is 
+	# of course not great) which makes it hard to compare. This should
+	# work. The main issue is this converts agg to a dataframe from a 
+	# geodataframe; but I don't think that changes anything (it doesn't
+	# have any geographic information anyways) 
+
+	fn = 'wm_export_test'
+
+	# Build sample dataset
+	ds = xr.Dataset({'test':(['lon','lat'],np.array([[0,1],[2,3]])),
+				 'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5]])),
+				 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5]]))},
+				coords={'lat':(['lat'],np.array([0,1])),
+						'lon':(['lon'],np.array([0,1])),
+						'bnds':(['bnds'],np.array([0,1]))})
+
+	# Add a simple weights grid
+	weights = xr.DataArray(data=np.array([[0,1],[2,3]]),
+								dims=['lat','lon'],
+								coords=[ds.lat,ds.lon])
+
+	# Create polygon covering one pixel
+	gdf = {'name':['test'],
+				'geometry':[Polygon([(-0.5,-0.5),(-0.5,0.5),(0.5,0.5),(0.5,-0.5),(-0.5,-0.5)])]}
+	gdf = gpd.GeoDataFrame(gdf,crs="EPSG:4326")
+
+	# Calculate weightmap
+	wm_out = pixel_overlaps(ds,gdf,weights=weights)
+
+	# Export weightmap
+	wm_out.to_file(fn,overwrite=True)
+
+	# Load weightmap
+	wm_in = read_wm(fn)
+
+
+	###### agg
+	# This is just checking the parts of the thing that aren't lists. Unfortunately putting lists into
+	# dataframes is a bad idea, but that's the best method I've come up with so far. 
+	pd.testing.assert_frame_equal(wm_out.agg[[v for v in wm_out.agg if v not in ['rel_area','pix_idxs','coords']]],
+								  wm_in.agg[[v for v in wm_in.agg if v not in ['rel_area','pix_idxs','coords']]])
+	# Now for the columns with lists
+	for v in ['rel_area','pix_idxs','coords']:
+		for it in np.arange(0,wm_out.agg[v].shape[0]):
+			np.testing.assert_array_equal(wm_out.agg[v].values[it],wm_in.agg[v].values[it])
+	# Now for the column names to make sure all the columns are remained
+	pd.testing.assert_index_equal(wm_out.agg.columns,wm_in.agg.columns)
+
+	###### geometry
+	gpdt.assert_geoseries_equal(wm_out.geometry,wm_in.geometry)
+
+	###### source grids
+	for k in wm_out.source_grid:
+		xr.testing.assert_equal(wm_out.source_grid[k],wm_in.source_grid[k])
+
+	###### weights
+	if (type(wm_out.weights) is str) and (wm_out.weights=='nowghts'):
+		np.testing.assert_string_equal(wm_in.weights,wm_out.weights)
+	else:
+		pd.testing.assert_series_equal(wm_in.weights,wm_out.weights)
+
+	##### clean 
+	shutil.rmtree(fn)
+

--- a/xagg/aux.py
+++ b/xagg/aux.py
@@ -1,8 +1,10 @@
 import xarray as xr
 import numpy as np
 import pandas as pd
+import geopandas as gpd
 import warnings
-
+import os
+import re
 
 def normalize(a,drop_na = False):
     """ Normalizes the vector `a`

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -1,5 +1,7 @@
-from .export import (prep_for_nc,prep_for_csv,output_data)
+from .export import (prep_for_nc,prep_for_csv,output_data,export_weightmap)
 import warnings
+import os
+import re
 
 try:
     import cartopy 
@@ -10,6 +12,12 @@ try:
     no_plotting = False
 except ImportError:
     no_plotting = True
+
+try:
+    import tables
+except ImportError:
+    no_hd5_output = True
+
 
 # POSSIBLE CHANGE: I'm not quite sure how python deals with memory
 # in this case - but [aggregated], which contains [ds] as one of its
@@ -39,6 +47,12 @@ class weightmap(object):
         # - the pixels overlapping polygon
         #    - shaded by the amount of overlapping area 
         #    - or the total weight (area+weight)
+
+    def to_file(self,fn,overwrite=False):
+        """ Save a copy of the weightmap, to avoid recalculating it
+        """
+        export_weightmap(self,fn,overwrite)
+
 
 
 class aggregated(object):

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -5,9 +5,82 @@ import geopandas as gpd
 from shapely.geometry import Polygon
 import warnings
 import xesmf as xe
+import re 
+import os
 
 from . aux import (normalize,fix_ds,get_bnds,subset_find)
 from . classes import (weightmap,aggregated)
+
+def read_wm(path):
+    """ Load temporary weightmap files from wm.to_file()
+
+    Builds a weightmap out of saved weightmap component 
+    files. Particularly useful if the weightmap took a 
+    particularly long time to calculated (i.e., if the 
+    grid is particularly high resolution). 
+
+    Assumes the files are generated from `wm.to_file()`; 
+    i.e., the files are all in a directory `name`: 
+
+    `name/name.shp` : the geometry of the input polygons
+    `name/name.agg` : the dataframe with the pixel overlap
+                      data
+    `name/name_lat.nc`, `name/name_lon.nc` : 
+                      the source grid of the raster data
+    `name/name_weights.nc` :
+                      the additional weights grid, if used
+                      (this file is optional; if no file
+                      with this name is found, no weights 
+                      are assumed, and 
+                      `wm.weights='noweights'`)
+
+    Parameters
+    ---------------
+    path : str 
+        The directory in which the files are stored. They
+        are assumed to follow the filename convention of
+        sharing the name of the directory (i.e., the last
+        part of this path.)
+
+    Returns
+    ---------------
+    wm : :class:`xagg.weightmap`
+
+    """
+    # the last bit of the path is also the filename
+    fn = re.split('/',path)[-1]
+    
+
+    ###### Load geometry
+    geo = gpd.read_file(path+'/'+fn+'.shp')
+    geo = geo['geometry']
+
+    ####### Load agg 
+    agg = pd.read_hdf(path+'/'+fn+'.h5', 'wm')
+
+    ###### Load source grid
+    source_grid = {k:xr.open_dataset(path+'/'+fn+'_'+k+'.nc').set_index({'loc':('lat','lon')})[k+'v'] for k in ['lat','lon']}
+
+    ###### Load weights
+    if os.path.exists(path+'/'+fn+'_weights.csv'):
+        # Specifying column because it saves it as with 
+        # a dummy index column that gets loaded in an 
+        # unproductive way
+        weights = pd.read_csv(path+'/'+fn+'_weights.csv')['weights'].astype(object)
+        # ^^ Setting astype(object) to make sure integral weights
+        # don't change the general type of the frame. This may
+        # only affect the testing routines, but setting this here
+        # to be explicit 
+    else:
+        weights = 'nowghts'
+
+    ###### Combine into weightmap
+    wm = weightmap(agg=agg,
+                   geometry=geo,
+                   source_grid=source_grid,
+                   weights=weights)
+
+    return wm
 
 
 def process_weights(ds,weights=None,target='ds'):

--- a/xagg/export.py
+++ b/xagg/export.py
@@ -2,10 +2,49 @@ import xarray as xr
 import pandas as pd
 import geopandas as gpd
 import numpy as np
-
+import os
+import warnings
 
 from . aux import (normalize,fix_ds,get_bnds,subset_find)
 
+
+def export_weightmap(wm_obj,fn,overwrite=False):
+    """ Save a copy of the weightmap, to avoid recalculating it
+    """
+    ###### NEED TO SETUP HD5 DEPENDENCY? THROUGH OPTIONAL DEPENDENCY MAYBE? 
+    warnings.warn('export_weightmap() is still an experimental feature. use with care.')
+
+
+    if (not overwrite) and (os.path.exists(fn)):
+        raise FileExistsError(fn+'/ already exists. Either change the [fn] or set overwrite=True.')
+
+    ###### Save geometry
+    # This also creates a folder, into which we can add the rest
+    # of the files
+    wm_obj.geometry.to_file(fn)
+
+    ####### Save agg 
+    # Turn into a dataframe from a geodataframe; only dataframes
+    # can be converted to HD5 files (and there's no geographic 
+    # information here that's needed; can all be saved in the 
+    # geographic save below)
+    df_out = pd.DataFrame(wm_obj.agg)
+    df_out.to_hdf(fn+'/'+fn+'.h5','wm')
+
+    ###### Save source grid
+    for k in wm_obj.source_grid:
+        # Adding v to variable (i.e., 'latv', 'lonv') needed 
+        # because of the multi-index being used here 
+        wm_obj.source_grid[k].reset_index('loc').to_dataset(name=k+'v').to_netcdf(fn+'/'+fn+'_'+k+'.nc')
+
+    ###### Save weights
+    # (If weights == 'nowghts', then no file to load)
+    if (type(wm_obj.weights) is not str) or (wm_obj.weights != 'nowghts'):
+        # Setting astype(object) to make sure integral weights
+        # don't change the general type of the frame. This may
+        # only affect the testing routines, but setting this here
+        # to be explicit 
+        wm_obj.weights.astype(object).to_csv(fn+'/'+fn+'_weights.csv')
 
 def prep_for_nc(agg_obj,loc_dim='poly_idx'):
     """ Preps aggregated data for output as a netcdf


### PR DESCRIPTION
Creates a `.to_file()` option for the `weightmap` class which allows exporting and importing (through `read_wm()`) the output from `pixel_overlaps()`. This is particularly useful for very large grids, where calculating pixel overlaps for each run of `xagg` is particularly resource-intensive. 