### PR TITLE
Local fixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,9 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          # mamba-version: "*" # activate this to build with mamba.
-          # channels: conda-forge, defaults # These need to be specified to use mamba
-          # channel-priority: true
+          mamba-version: "*" # activate this to build with mamba.
+          channels: conda-forge, defaults # These need to be specified to use mamba
+          channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml
 
           activate-environment: test_env_xagg_new

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,22 +11,17 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.10"]
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache conda
-        uses: actions/cache@v1
-        env:
-          # Increase this value to reset cache if ci/environment.yml has not changed
-          CACHE_NUMBER: 0
+      - uses: actions/checkout@v3
+      - name: Create conda environment
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
+          cache-downloads: true
+          cache-env: true
+          micromamba-version: 'latest'
           #mamba-version: "*" # activate this to build with mamba.
           channels: conda-forge #, defaults # These need to be specified to use mamba
           channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml
-
           activate-environment: test_env_xagg_new
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Set up conda environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*" # activate this to build with mamba.
-          channels: conda-forge#, defaults # These need to be specified to use mamba
+          channels: conda-forge #, defaults # These need to be specified to use mamba
           channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*" # activate this to build with mamba.
+          #mamba-version: "*" # activate this to build with mamba.
           channels: conda-forge #, defaults # These need to be specified to use mamba
           channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
@@ -23,7 +23,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*" # activate this to build with mamba.
-          channels: conda-forge, defaults # These need to be specified to use mamba
+          channels: conda-forge#, defaults # These need to be specified to use mamba
           channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,6 @@ jobs:
           channels: conda-forge #, defaults # These need to be specified to use mamba
           channel-priority: true
           environment-file: ci/environment-py${{ matrix.python-version }}.yml
-          activate-environment: test_env_xagg_new
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Set up conda environment
         shell: bash -l {0}
         run: |

--- a/ci/environment-py3.10.yml
+++ b/ci/environment-py3.10.yml
@@ -1,8 +1,8 @@
-name: test_env_xagg_37
+name: test_env_xagg_new
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.10
   ############## These will have to be adjusted to your specific project
   - numpy
   - scipy
@@ -22,4 +22,4 @@ dependencies:
     - codecov
     - pytest-cov
     - coverage[toml]
-    #- tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)
+   # - tables >= 3.7.0 # For exporting hd5 files through wm.to_file() (3.6.0 may have issues)

--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -9,9 +9,9 @@ dependencies:
   - xarray
   - pandas
   - netcdf4
-  - geopandas
+  - geopandas >= 0.12.0
   - shapely
-  - xesmf >= 0.5.2 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
+  - xesmf >= 0.7.1 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 

--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -11,7 +11,7 @@ dependencies:
   - netcdf4
   - geopandas >= 0.12.0
   - shapely
-  - xesmf >= 0.7.1 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
+  - xesmf >= 0.7.0 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -9,9 +9,9 @@ dependencies:
   - xarray
   - pandas
   - netcdf4
-  - geopandas
+  - geopandas >= 0.12.0
   - shapely
-  - xesmf >= 0.5.2 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
+  - xesmf >= 0.7.1 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -11,7 +11,7 @@ dependencies:
   - netcdf4
   - geopandas >= 0.12.0
   - shapely
-  - xesmf >= 0.7.1 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
+  - xesmf >= 0.7.0 # These versions and explicit loads are to fix an issue in xesmf's call to cf_xarray (possibly through esmpy) 
   - cf_xarray >= 0.5.1
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - scipy
   - netcdf4
   - pandas
-  - geopandas
-  - xesmf >= 0.5.2
+  - geopandas >= 0.12.0
+  - xesmf >= 0.7.1
   - cf_xarray # separately, to ensure latest version
   - pytables

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -62,7 +62,7 @@ def test_to_dataframe(agg=agg):
 
 ##### pixel_overlaps() export tests #####
 
-def test_pixel_overlaps_export_and_import():
+def test_pixel_overlaps_export_and_import(ds=ds):
 	# Testing the .to_file() --> read_wm() workflow. 
 	# Rather complex because of the many different components of wm. 
 	# wm.agg in particular is a dataframe with lists in it (which is 
@@ -74,12 +74,12 @@ def test_pixel_overlaps_export_and_import():
 	fn = 'wm_export_test'
 
 	# Build sample dataset
-	ds = xr.Dataset({'test':(['lon','lat'],np.array([[0,1],[2,3]])),
-				 'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5]])),
-				 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5]]))},
-				coords={'lat':(['lat'],np.array([0,1])),
-						'lon':(['lon'],np.array([0,1])),
-						'bnds':(['bnds'],np.array([0,1]))})
+	#ds = xr.Dataset({'test':(['lon','lat'],np.array([[0,1],[2,3]])),
+	#			 'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5]])),
+	#			 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5]]))},
+	#			coords={'lat':(['lat'],np.array([0,1])),
+	#					'lon':(['lon'],np.array([0,1])),
+	#					'bnds':(['bnds'],np.array([0,1]))})
 
 	# Add a simple weights grid
 	weights = xr.DataArray(data=np.array([[0.,1.],[2.,3.]]).astype(object),
@@ -118,7 +118,7 @@ def test_pixel_overlaps_export_and_import():
 
 	###### source grids
 	for k in wm_out.source_grid:
-		xr.testing.assert_equal(wm_out.source_grid[k],wm_in.source_grid[k])
+		xr.testing.assert_allclose(wm_out.source_grid[k],wm_in.source_grid[k])
 
 	###### weights
 	if (type(wm_out.weights) is str) and (wm_out.weights=='nowghts'):

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -403,8 +403,11 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
         # Get relative area of each pixel
         overlaps = overlaps.groupby('poly_idx').apply(find_rel_area)
         # This creates an extra index of poly_idx which duplicates
-        # the existing column,... so remove those columns. 
-        overlaps = overlaps.drop(['poly_idx'],axis=1).reset_index().drop('level_1',axis=1)
+        # the existing column,... so remove those columns. `level_1`
+        # doesn't show up in the python 3.8 tests (?); so to be robust
+        # specify the remaining columns to keep instead.
+        overlaps = overlaps.drop(['poly_idx'],axis=1).reset_index()
+        overlaps = overlaps[['poly_idx','name','lat','lon','pix_idx','geometry','rel_area']]#drop('level_1',axis=1)
         overlaps['lat'] = overlaps['lat'].astype(float)
         overlaps['lon'] = overlaps['lon'].astype(float)
 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -401,13 +401,7 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
     
     if impl=='dot_product':
         # Get relative area of each pixel
-        overlaps = overlaps.groupby('poly_idx').apply(find_rel_area)
-        # This creates an extra index of poly_idx which duplicates
-        # the existing column,... so remove those columns. `level_1`
-        # doesn't show up in the python 3.8 tests (?); so to be robust
-        # specify the remaining columns to keep instead.
-        overlaps = overlaps.drop(['poly_idx'],axis=1).reset_index()
-        overlaps = overlaps[['poly_idx','name','lat','lon','pix_idx','geometry','rel_area']]#drop('level_1',axis=1)
+        overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area)
         overlaps['lat'] = overlaps['lat'].astype(float)
         overlaps['lon'] = overlaps['lon'].astype(float)
 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -60,6 +60,8 @@ def read_wm(path):
 
     ###### Load source grid
     source_grid = {k:xr.open_dataset(path+'/'+fn+'_'+k+'.nc').set_index({'loc':('lat','lon')})[k+'v'] for k in ['lat','lon']}
+    # Rename, removing the v added for the multi-index issue in export
+    source_grid = {k:v.rename(k) for k,v in source_grid.items()}
 
     ###### Load weights
     if os.path.exists(path+'/'+fn+'_weights.csv'):
@@ -263,10 +265,9 @@ def create_raster_polygons(ds,
     pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
     
     # Create empty geodataframe
-    gdf_pixels = gpd.GeoDataFrame()
-    gdf_pixels['lat'] = [None]*ds_bnds.dims['loc']
-    gdf_pixels['lon'] = [None]*ds_bnds.dims['loc']
-    gdf_pixels['geometry'] = [None]*ds_bnds.dims['loc']
+    gdf_pixels = gpd.GeoDataFrame(pd.DataFrame({v:[None]*ds_bnds.dims['loc']
+                               for v in ['lat','lon','geometry']}),
+                              geometry='geometry')
     if weights is not None:
         # Stack weights so they are linearly indexed like the ds (and fill
         # NAs with 0s)
@@ -371,7 +372,8 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
     # Match up CRSes
     pix_agg['gdf_pixels'] = pix_agg['gdf_pixels'].to_crs(gdf_in.crs)
 
-    # Get GeoDataFrame of the overlaps between every pixel and the polygons
+    # Choose a common crs for both, just to minimize the chance
+    # of geographic shenanigans
     # (using the EASE grid https://nsidc.org/data/ease)
     if np.all(gdf_in.total_bounds[[1,3]]>0):
         # If min/max lat are both in NH, use North grid
@@ -386,12 +388,23 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
         #epsg_set = {'init':'EPSG:6933'}
         epsg_set = 'EPSG:6933'
     
-    overlaps = gpd.overlay(gdf_in.to_crs(epsg_set),
-                           pix_agg['gdf_pixels'].to_crs(epsg_set),
-                           how='intersection')
+    # Get GeoDataFrame of the overlaps between every pixel and the polygons
+    with warnings.catch_warnings():
+        # Filter UserWarnings that flag when overlapping would result in 
+        # lines, or point overlaps (but we only care about 3D overlaps, so
+        # keep_geom_type=True is the right call, and we don't need the 
+        # warning)
+        warnings.filterwarnings('ignore',category=UserWarning)
+        overlaps = gpd.overlay(gdf_in.to_crs(epsg_set),
+                               pix_agg['gdf_pixels'].to_crs(epsg_set),
+                               how='intersection')
     
     if impl=='dot_product':
+        # Get relative area of each pixel
         overlaps = overlaps.groupby('poly_idx').apply(find_rel_area)
+        # This creates an extra index of poly_idx which duplicates
+        # the existing column,... so remove those columns. 
+        overlaps = overlaps.drop(['poly_idx'],axis=1).reset_index().drop('level_1',axis=1)
         overlaps['lat'] = overlaps['lat'].astype(float)
         overlaps['lon'] = overlaps['lon'].astype(float)
 

--- a/xagg/export.py
+++ b/xagg/export.py
@@ -32,7 +32,10 @@ def export_weightmap(wm_obj,fn,overwrite=False):
         # information here that's needed; can all be saved in the 
         # geographic save below)
         df_out = pd.DataFrame(wm_obj.agg)
-        df_out.to_hdf(fn+'/'+re.split('\/',fn)[-1]+'.h5','wm')
+        with warnings.catch_warnings():
+            # Catch performance warning about pickling
+            warnings.filterwarnings('ignore')
+            df_out.to_hdf(fn+'/'+re.split('\/',fn)[-1]+'.h5','wm')
 
         ###### Save source grid
         for k in wm_obj.source_grid:


### PR DESCRIPTION
## Errors 
Fixed failed core test on dot product implementation
- dot product implementation created an extra mulit-index in the gdf that was causing problems

Fixed failed export test on exporting weightmap
- replaced `xr.testing.assert_equal()` with `xr.testing.assert_allclose()`, which is good enough for what was being checked

Fixed failed CI environment construction
- updated workflow to more recent mamba environment scripts 

## Warnings
Filtered out UserWarning on `gpd.overlay()` in certain tests
- this warning would appear if a pixel exactly touched a polygon at a line or a point, in which case the code would (correctly) not count an "overlap", but gpd would throw a warning that the "overlay"'ed Line and/or Point were being (correctly) dropped by `keep_geom_type=True`

Removed cause of `gpd` FutureWarning in `get_pixel_overlaps()`
- a geodataframe was being initalized and then populated; now it is created in one step using `gpd.GeoDataFrame()`, which is more robust