### PR TITLE
Fixing wraparound issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 
+# Test things
+*test*.ipynb
+
 # C extensions
 *.so
 

--- a/tests/test_auxfuncs.py
+++ b/tests/test_auxfuncs.py
@@ -10,7 +10,7 @@ def test_normalize():
 	assert np.allclose(normalize(np.array([1,1])),np.array([0.5,0.5]))
 
 
-##### fix_ds tests #####
+##### fix_ds() tests #####
 def test_fix_ds_null():
 	# If lat, lon correctly named, lon as -180:180, bounds correctly named, sorted, that nothing happens
 	ds = xr.Dataset({'test':(['lat','lon'],np.array([[0,1,2],[3,4,5],[6,7,8]])),
@@ -32,8 +32,8 @@ def test_fix_ds_rename():
 	ds = xr.Dataset(coords={'Latitude':(['Latitude'],np.array([0,1,2])),
 							'Longitude':(['Longitude'],np.array([0,1,2]))})
 	ds = fix_ds(ds)
-	assert ('lat' in ds.dims.keys())
-	assert ('lon' in ds.dims.keys())
+	assert ('lat' in ds.sizes)
+	assert ('lon' in ds.sizes)
 
 def test_fix_ds_rename_bnds():
 	# Test whether the bounds are renamed correctly
@@ -79,7 +79,7 @@ def test_fix_ds_coord_sorting():
 
 
 
-###### get_bnds tests #####
+###### get_bnds() tests #####
 def test_get_bnds_null():
 	# If there are bounds already, do nothing
 	ds = xr.Dataset({'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5],[1.5,2.5]])),
@@ -106,7 +106,7 @@ def test_get_bnds_basic():
 	
 
 def test_get_bnds_wraparound():
-	# Basic attempt to get the bounds (far away from the wraparound)
+	# Make sure that lons wrap around, but lats don't
 	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-89.4,89.7)),
 							'lon':(['lon'],np.arange(-179.4,179.7))})
 	ds = get_bnds(ds)
@@ -123,10 +123,9 @@ def test_get_bnds_wraparound():
 
 	xr.testing.assert_allclose(ds,ds_compare)
 
-#def test_get_bnds_badwraparound():
+# def test_get_bnds_badwraparound
 	# THERE ARE A LOT OF ISSUES LEFT WITH THIS - 360s showing up somehow, even though it's not in the "edges"... idk man
-	# Try a test taht does some weird subset, like (-178:183). Also make sure that -89.9 gets turned to -90. 
-
+	# Try a test that does some weird subset, like (-178:183). Also make sure that -89.9 gets turned to -90. 
 
 
 ###### subset_find tests #####

--- a/tests/test_auxfuncs.py
+++ b/tests/test_auxfuncs.py
@@ -85,8 +85,7 @@ def test_get_bnds_null():
 	ds = xr.Dataset({'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5],[1.5,2.5]])),
 					 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5],[1.5,2.5]]))},
 					coords={'lat':(['lat'],np.array([0,1,2])),
-							'lon':(['lon'],np.array([0,1,2])),
-							'bnds':(['bnds'],np.array([0,1]))})
+							'lon':(['lon'],np.array([0,1,2]))})
 
 	xr.testing.assert_allclose(ds,get_bnds(ds))
 
@@ -99,33 +98,120 @@ def test_get_bnds_basic():
 	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],np.array([[-0.5,0.5],[0.5,1.5],[1.5,2.5]])),
 					 		 'lon_bnds':(['lon','bnds'],np.array([[-0.5,0.5],[0.5,1.5],[1.5,2.5]]))},
 							coords={'lat':(['lat'],np.array([0,1,2])),
-									'lon':(['lon'],np.array([0,1,2])),
-									'bnds':(['bnds'],np.array([0,1]))})
+									'lon':(['lon'],np.array([0,1,2]))})
 
 	xr.testing.assert_allclose(ds,ds_compare)
 	
 
-def test_get_bnds_wraparound():
-	# Make sure that lons wrap around, but lats don't
-	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-89.4,89.7)),
-							'lon':(['lon'],np.arange(-179.4,179.7))})
+def test_get_bnds_fullgrid():
+	# -179.5:179.5, with bounds exactly at 180/-180
+	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-89.5,89.51)), 
+	                    	'lon':(['lon'],np.arange(-179.5,179.51))})
 	ds = get_bnds(ds)
 
-	lats = np.array(list(zip(np.arange(-89.9,89.91),np.arange(-88.9,90.9))))
-	lats[-1,1] = 90.0
-	lons = np.array(list(zip(np.arange(-179.9,179.91),np.arange(-178.9,180.9))))
-	lons[-1,1] = -179.9
-	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lats),
-					 		 'lon_bnds':(['lon','bnds'],lons)},
-							coords={'lat':(['lat'],np.arange(-89.4,89.7)),
-									'lon':(['lon'],np.arange(-179.4,179.7)),
-									'bnds':(['bnds'],np.array([0,1]))})
+	lat_bnds = np.array(list(zip(np.arange(-90,89.91),np.arange(-89,90.1))))
+	lon_bnds = np.array(list(zip(np.arange(-180,179.01),np.arange(-179,180.01))))
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.arange(-89.5,89.51)),
+	                                'lon':(['lon'],np.arange(-179.5,179.51))})
 
 	xr.testing.assert_allclose(ds,ds_compare)
 
-# def test_get_bnds_badwraparound
-	# THERE ARE A LOT OF ISSUES LEFT WITH THIS - 360s showing up somehow, even though it's not in the "edges"... idk man
-	# Try a test that does some weird subset, like (-178:183). Also make sure that -89.9 gets turned to -90. 
+def test_get_bnds_truncatedlats():
+	# Tests to make sure grids are truncated to 90/-90 when needed
+	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-90,90.01)), 
+	                    	'lon':(['lon'],np.arange(-180,179.01))})
+	ds = get_bnds(ds)
+
+	lat_bnds = np.array(list(zip(np.arange(-90.5,89.51),np.arange(-89.5,90.51))))
+	lat_bnds[0,0] = -90; lat_bnds[-1,-1] = 90
+	lon_bnds = np.array(list(zip(np.arange(-180.5,178.51),np.arange(-179.5,179.51))))
+	lon_bnds[0,0] = 179.5
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.arange(-90,90.01)),
+	                                'lon':(['lon'],np.arange(-180,179.01))})
+
+	xr.testing.assert_allclose(ds,ds_compare)
+
+def test_get_bnds_partialgrid():
+	# Partial grid, that should _not_ be wrapped around (farther
+	# than the dynamic wrap_around limit = 2*median lon diff)
+	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-89.5,89.51)), 
+	                    	'lon':(['lon'],np.arange(-179.5,177.51))})
+	ds = get_bnds(ds)
+
+	lat_bnds = np.array(list(zip(np.arange(-90,89.91),np.arange(-89,90.1))))
+	lon_bnds = np.array(list(zip(np.arange(-180,177.01),np.arange(-179,178.01))))
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.arange(-89.5,89.51)),
+	                                'lon':(['lon'],np.arange(-179.5,177.51))})
+
+	xr.testing.assert_allclose(ds,ds_compare)
+
+def test_get_bnds_offsetgrid():
+	# Full planetary grid, but with pixels crossing the antimeridian
+	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-89.4,89.7)), #  -180:180, offset
+                        	'lon':(['lon'],np.arange(-179.4,179.7))})
+
+	ds = get_bnds(ds)
+
+	lat_bnds = np.array(list(zip(np.arange(-89.9,89.11),np.arange(-88.9,90.11))))
+	lat_bnds[-1,-1] = 90 # Truncate at 90
+	lon_bnds = np.array(list(zip(np.arange(-179.9,179.11),np.arange(-178.9,180.11))))
+	lon_bnds[-1,-1] = -179.9 # Wrap around across antimeridian
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.arange(-89.4,89.7)),
+	                                'lon':(['lon'],np.arange(-179.4,179.7))})
+
+	xr.testing.assert_allclose(ds,ds_compare)
+
+def test_get_bnds_1pixelinEH():
+	# Crossing the antimeridian, with just one pixel that is on the
+	# other side of the antimeridian, EH version (this can be an 
+	# issue with the code)
+	ds = xr.Dataset(coords={'lat':(['lat'],np.array([0,1])),
+	                        'lon':(['lon'],np.array([-179.8, -178.8,179.2]))})
+
+	ds = get_bnds(ds)
+
+	lat_bnds = np.array(list(zip(np.arange(-0.5,0.51),np.arange(0.5,1.51))))
+	lon_bnds = np.array([[179.7,-179.3],
+	                      [-179.3,-178.3],
+	                      [178.7,179.7]])
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.array([0,1])),
+	                        'lon':(['lon'],np.array([-179.8, -178.8,179.2]))})
+
+	xr.testing.assert_allclose(ds,ds_compare)
+
+
+
+def test_get_bnds_1pixelinWH():
+	# Crossing the antimeridian, with just one pixel that is on the
+	# other side of the antimeridian, WH version (this can be an 
+	# issue with the code)
+	ds = xr.Dataset(coords={'lat':(['lat'],np.array([0,1])),
+	                        'lon':(['lon'],np.array([-179.8, 178.2,179.2]))})
+
+	ds = get_bnds(ds)
+
+	lat_bnds = np.array(list(zip(np.arange(-0.5,0.51),np.arange(0.5,1.51))))
+	lon_bnds = np.array(list(zip(np.arange(176.7,178.71),np.arange(177.7,179.71))))
+	lon_bnds[0,0] = 179.7
+	lon_bnds[0,1] = -179.3
+	ds_compare = xr.Dataset({'lat_bnds':(['lat','bnds'],lat_bnds),
+	                         'lon_bnds':(['lon','bnds'],lon_bnds)},
+	                        coords={'lat':(['lat'],np.array([0,1])),
+	                        'lon':(['lon'],np.array([-179.8, 178.2,179.2]))})
+
+	xr.testing.assert_allclose(ds,ds_compare)
+
+
 
 
 ###### subset_find tests #####

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -154,9 +154,6 @@ def test_create_raster_polygons_at180():
 	# Create polygon grid from raster grid cells
 	pix_agg = create_raster_polygons(ds,weights=None)
 
-	wm_out = get_pixel_overlaps(gdf_test,pix_agg)
-	print(wm_out.agg)
-
 	# There shouldn't be any overlaps between this dataset and those
 	# pixels, so we expect the NoOverlapError to happen
 	with pytest.raises(NoOverlapError):

--- a/xagg/aux.py
+++ b/xagg/aux.py
@@ -227,7 +227,7 @@ def get_bnds(ds,
         print('lat/lon bounds not found in dataset; they will be created.')
         # Build lat / lon bound 
         for var in ['lat','lon']:
-            bnds_tmp = xr.DataArray(data=np.zeros((ds.dims[var],2))*np.nan,
+            bnds_tmp = xr.DataArray(data=np.zeros((ds.sizes[var],2))*np.nan,
                                     dims=[var,'bnds'],
                                     coords=[ds[var],np.arange(0,2)])
 
@@ -260,7 +260,7 @@ def get_bnds(ds,
                     # (to avoid wrapping around if a grid is only -180:45 for example)
                     if np.min(np.abs(bnds_tmp[-1,1].values-edges[var])) <= wrap_around_thresh:
                         if np.min(np.abs(bnds_tmp[-1,1].values-edges[var])) > ds[var].diff(var).max():
-                            warnings.warn('Wrapping around '+[var]+' value of '+bnds_tmp[-1,1].values+', '+
+                            warnings.warn('Wrapping around '+var+' value of '+str(bnds_tmp[-1,1].values)+', '+
                                           'because it is closer to a coordinate edge ('+
                                           ', '.join([str(n) for n in edges[var]])+') than the '+
                                           '[wrap_around_thresh] ('+str(wrap_around_thresh)+'); '+
@@ -272,7 +272,7 @@ def get_bnds(ds,
                 elif (bnds_tmp[0,0] not in edges[var]) & (bnds_tmp[-1,1] in edges[var]):
                     if np.min(np.abs(bnds_tmp[0,0].values-edges[var])) <= wrap_around_thresh:
                         if np.min(np.abs(bnds_tmp[0,0].values-edges[var])) > ds[var].diff(var).max():
-                            warnings.warn('Wrapping around '+[var]+' value of '+bnds_tmp[0,0].values+', '+
+                            warnings.warn('Wrapping around '+var+' value of '+str(bnds_tmp[0,0].values)+', '+
                                           'because it is closer to a coordinate edge ('+
                                           ', '.join([str(n) for n in edges[var]])+') than the '+
                                           '[wrap_around_thresh] ('+str(wrap_around_thresh)+'); '+

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -39,15 +39,19 @@ class weightmap(object):
         self.weights = weights
         self.overlap_da = overlap_da
         
-    def diag_fig(self,poly_idx):
-        """ (NOT YET IMPLEMENTED) a diagnostic figure of the aggregation
+    def diag_fig(self,poly_id,ds):
+        """ Create a diagnostic figure showing overlap between pixels and a given polygon
+
+        See `xagg.diag.diag_fig()` for more info. 
         """
-        raise NotImplementedError('diagnostic figure not yet implemented.')
-        # Eventually, will print a diagnostic figure showing 
-        # - the polygon defined by "poly_idx"
-        # - the pixels overlapping polygon
-        #    - shaded by the amount of overlapping area 
-        #    - or the total weight (area+weight)
+        try: 
+            from . diag import diag_fig
+        except ImportError:
+            raise ImportError('`wm.diag_fig()` separately requires `cartopy` and `matplotlib` to function; make sure these are installed first.')
+
+        
+        # Plot diagnostic figure
+        diag_fig(self,poly_id,ds)
 
     def to_file(self,fn,overwrite=False):
         """ Save a copy of the weightmap, to avoid recalculating it

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -3,13 +3,18 @@ import numpy as np
 import pandas as pd
 import geopandas as gpd
 from shapely.geometry import Polygon
+from shapely.geometry import MultiPolygon
 import warnings
-import xesmf as xe
 import re 
 import os
 
 from . aux import (find_rel_area,normalize,fix_ds,get_bnds,subset_find,list_or_first)
 from . classes import (weightmap,aggregated)
+
+class NoOverlapError(Exception):
+    """ Exception for when there's no overlap between pixels and polygons """
+    pass
+
 
 def read_wm(path):
     """ Load temporary weightmap files from wm.to_file()
@@ -147,6 +152,10 @@ def process_weights(ds,weights=None,target='ds',silent=False):
         # floating-point precision)
         if ((not ((ds.sizes['lat'] == weights.sizes['lat']) & (ds.sizes['lon'] == weights.sizes['lon']))) or 
             (not (np.allclose(ds.lat,weights.lat) & np.allclose(ds.lon,weights.lon)))):
+            # Import xesmf here to allow the code to work without it (it 
+            # often has dependency issues and isn't necessary for many 
+            # features of xagg)
+            import xesmf as xe
             if target == 'ds':
                 if not silent:
                     print('regridding weights to data grid...')
@@ -175,9 +184,33 @@ def process_weights(ds,weights=None,target='ds',silent=False):
     return ds,weights_info
 
 
+def make_multipoly(pts):
+    ''' Split pixel overlapping the antimeridian into MultiPolygon with 
+        each sub-Polygon in its own hemisphere
+
+    NB: to be used in `create_raster_polygons()`
+        
+    '''
+    pts = np.array(pts)
+    # Get which pixels are east of the antimeridian
+    neg = pts[:,0]<0
+
+    # Get point order for split up pixel 
+    pts = [ # west of antimeridian
+            np.vstack([pts[~neg],np.array([[180,x[1]] for x in pts[~neg][::-1]])]),
+            # east of antimeridian
+           np.vstack([np.array([[-180,x[1]] for x in pts[neg][::-1]]),pts[neg]])]
+    pts = [[tuple(x) for x in pt] for pt in pts]
+
+    # Create multipolygon
+    return MultiPolygon([Polygon(pt) for pt in pts])
+
+
+
 def create_raster_polygons(ds,
                            mask=None,subset_bbox=None,
-                           weights=None,weights_target='ds'):
+                           weights=None,weights_target='ds',
+                           wrap_around_thresh=5):
     """ Create polygons for each pixel in a raster
 
     Note: 
@@ -250,7 +283,7 @@ def create_raster_polygons(ds,
         
     # Create dataset which has a lat/lon bound value for each individual pixel, 
     # broadcasted out over each lat/lon pair
-    (ds_bnds,) = (xr.broadcast(ds.isel({d:0 for d in [k for k in ds.dims.keys() if k not in ['lat','lon','bnds']]}).
+    (ds_bnds,) = (xr.broadcast(ds.isel({d:0 for d in [k for k in ds.sizes if k not in ['lat','lon','bnds']]}).
                               drop_vars([v for v in ds.keys() if v not in ['lat_bnds','lon_bnds']])))
     # Stack so it's just pixels and bounds
     ds_bnds = ds_bnds.stack(loc=('lat','lon'))
@@ -267,9 +300,16 @@ def create_raster_polygons(ds,
     # and convert each of those vertices to tuples. This means every element
     # of pix_poly_coords is the input to shapely.geometry.Polygon of one pixel
     pix_poly_coords = tuple(map(tuple,np.reshape(pix_poly_coords,(np.shape(pix_poly_coords)[0],4,2))))
-    
+
+    # Figure out if any pixels cross the antimeridian; we'll have to deal with 
+    # those separately... Identify them by seeing which pixels have longitudes
+    # that are within the `wrap_around_thresh` (by default 5 degs) of both 
+    # +180 and -180 degrees
+    cross_antimeridian_idxs = ((np.abs(np.array(pix_poly_coords)[:,:,0] - -180) < wrap_around_thresh).any(axis=1) & 
+     (np.abs(np.array(pix_poly_coords)[:,:,0] - 180) < wrap_around_thresh).any(axis=1))
+
     # Create empty geodataframe
-    gdf_pixels = gpd.GeoDataFrame(pd.DataFrame({v:[None]*ds_bnds.dims['loc']
+    gdf_pixels = gpd.GeoDataFrame(pd.DataFrame({v:[None]*ds_bnds.sizes['loc']
                                for v in ['lat','lon','geometry']}),
                               geometry='geometry')
     if weights is not None:
@@ -277,14 +317,18 @@ def create_raster_polygons(ds,
         # NAs with 0s)
         weights = ds.weights.stack(loc=('lat','lon')).fillna(0)
         # Preallocate weights column
-        gdf_pixels['weights'] = [None]*ds_bnds.dims['loc']
+        gdf_pixels['weights'] = [None]*ds_bnds.sizes['loc']
     
-    # Now populate with a polygon for every pixel, and the lat/lon coordinates
-    # of that pixel 
+    # Now populate with a polygon for every pixel
     poly_dict = {'poly_pts': pix_poly_coords}
     df_poly = pd.DataFrame(poly_dict, columns=['poly_pts'])
-    df_poly['poly']=df_poly.poly_pts.apply(lambda pts: Polygon(pts))
+    df_poly['poly'] = df_poly.poly_pts.apply(lambda pts: Polygon(pts))
+    # Make MultiPolygons for pixels crossing the antimeridian
+    print(cross_antimeridian_idxs)
+    df_poly.loc[np.where(cross_antimeridian_idxs)[0],'poly'] = df_poly.poly_pts.iloc[np.where(cross_antimeridian_idxs)[0]].apply(lambda pts: make_multipoly(pts))
+    # Set geometry 
     gdf_pixels['geometry']=df_poly['poly']
+    # Add lat/lons of pixels for identification 
     gdf_pixels['lat']=ds_bnds.lat.values
     gdf_pixels['lon']=ds_bnds.lon.values  
     if weights is not None:
@@ -403,29 +447,32 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl='for_loop'):
                                pix_agg['gdf_pixels'].to_crs(epsg_set),
                                how='intersection')
     
-    if impl=='dot_product':
-        # Get relative area of each pixel
-        overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area)
-        overlaps['lat'] = overlaps['lat'].astype(float)
-        overlaps['lon'] = overlaps['lon'].astype(float)
+    if overlaps.empty:
+        raise NoOverlapError('No `ds` grid cells overlapped with any polygon in `gdf_in`. Check the input `ds` and `gdf_in`.')
+    else:
+        if impl=='dot_product':
+            # Get relative area of each pixel
+            overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area)
+            overlaps['lat'] = overlaps['lat'].astype(float)
+            overlaps['lon'] = overlaps['lon'].astype(float)
 
-        # Now, group by poly_idx (each polygon in the shapefile)
-        ov_groups = overlaps.groupby('poly_idx')
+            # Now, group by poly_idx (each polygon in the shapefile)
+            ov_groups = overlaps.groupby('poly_idx')
 
-        overlap_info = ov_groups.agg(list_or_first)
+            overlap_info = ov_groups.agg(list_or_first)
 
-        overlap_info = overlap_info.rename(columns={'pix_idx': 'pix_idxs'})
-    elif impl=='for_loop':
-        # Now, group by poly_idx (each polygon in the shapefile)
-        ov_groups = overlaps.groupby('poly_idx')
-        # Calculate relative area of each overlap (so how much of the total 
-        # area of each polygon is taken up by each pixel), the pixels 
-        # corresponding to those areas, and the lat/lon coordinates of 
-        # those pixels
-        overlap_info = ov_groups.agg(rel_area=pd.NamedAgg(column='geometry',aggfunc=lambda ds: [normalize(ds.area)]),
-                                       pix_idxs=pd.NamedAgg(column='pix_idx',aggfunc=lambda ds: [idx for idx in ds]),
-                                       lat=pd.NamedAgg(column='lat',aggfunc=lambda ds: [x for x in ds]),
-                                       lon=pd.NamedAgg(column='lon',aggfunc=lambda ds: [x for x in ds]))
+            overlap_info = overlap_info.rename(columns={'pix_idx': 'pix_idxs'})
+        elif impl=='for_loop':
+            # Now, group by poly_idx (each polygon in the shapefile)
+            ov_groups = overlaps.groupby('poly_idx')
+            # Calculate relative area of each overlap (so how much of the total 
+            # area of each polygon is taken up by each pixel), the pixels 
+            # corresponding to those areas, and the lat/lon coordinates of 
+            # those pixels
+            overlap_info = ov_groups.agg(rel_area=pd.NamedAgg(column='geometry',aggfunc=lambda ds: [normalize(ds.area)]),
+                                           pix_idxs=pd.NamedAgg(column='pix_idx',aggfunc=lambda ds: [idx for idx in ds]),
+                                           lat=pd.NamedAgg(column='lat',aggfunc=lambda ds: [x for x in ds]),
+                                           lon=pd.NamedAgg(column='lon',aggfunc=lambda ds: [x for x in ds]))
 
     # Zip lat, lon columns into a list of (lat,lon) coordinates
     # (separate from above because as of 12/20, named aggs with 
@@ -569,7 +616,7 @@ def aggregate(ds,wm,impl='for_loop',silent=False):
         for var in ds:
             # Process for every variable that has locational information, but isn't a 
             # bound variable
-            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+            if ('bnds' not in ds[var].sizes) & ('loc' in ds[var].sizes):
                 if not silent:
                     print('aggregating '+var+'...')
 
@@ -607,7 +654,7 @@ def aggregate(ds,wm,impl='for_loop',silent=False):
 
         wm.agg = pd.merge(wm.agg, df_combined, on='poly_idx')
         for var in ds:
-            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+            if ('bnds' not in ds[var].sizes) & ('loc' in ds[var].sizes):
                 # convert to list of arrays - NOT SURE THIS IS THE RIGHT THING TO
                 # DO, JUST TRYING TO MATCH ORIGINAL FORMAT
                 wm.agg[var] = wm.agg[var].apply(np.array).apply(lambda x: [x])
@@ -619,7 +666,7 @@ def aggregate(ds,wm,impl='for_loop',silent=False):
         for var in ds:
             # Process for every variable that has locational information, but isn't a 
             # bound variable
-            if ('bnds' not in ds[var].dims) & ('loc' in ds[var].dims):
+            if ('bnds' not in ds[var].sizes) & ('loc' in ds[var].sizes):
                 if not silent:
                     print('aggregating '+var+'...')
                 # Create the column for the relevant variable
@@ -637,14 +684,14 @@ def aggregate(ds,wm,impl='for_loop',silent=False):
                     # in both cases; the "aggregated variable" is just a vector of nans. 
                     if not np.isnan(wm.agg.iloc[poly_idx,:].pix_idxs).all():
                         # Get the dimensions of the variable that aren't "loc" (location)
-                        other_dims = [k for k in np.atleast_1d(ds[var].dims) if k != 'loc']
+                        other_dims = [k for k in np.atleast_1d(ds[var].sizes) if k != 'loc']
                         # Check first if any nans are "complete" (meaning that a pixel 
                         # either has values for each step, or nans for each step - if
                         # there are random nans within a pixel, throw a warning)
                         if not xr.Dataset.equals(np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).any(other_dims),
                                                   np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).all(other_dims)):
                             warnings.warn('One or more of the pixels in variable '+var+' have nans in them in the dimensions '+
-                                           ', '.join([k for k in ds[var].dims if k != 'loc'])+
+                                           ', '.join([k for k in ds[var].sizes if k != 'loc'])+
                                            '. The code can currently only deal with pixels for which the '+
                                            '*entire* pixel has nan values in all dimensions, however there is currently no '+
                                            ' support for data in which pixels have only some nan values. The aggregation '+

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -324,7 +324,6 @@ def create_raster_polygons(ds,
     df_poly = pd.DataFrame(poly_dict, columns=['poly_pts'])
     df_poly['poly'] = df_poly.poly_pts.apply(lambda pts: Polygon(pts))
     # Make MultiPolygons for pixels crossing the antimeridian
-    print(cross_antimeridian_idxs)
     df_poly.loc[np.where(cross_antimeridian_idxs)[0],'poly'] = df_poly.poly_pts.iloc[np.where(cross_antimeridian_idxs)[0]].apply(lambda pts: make_multipoly(pts))
     # Set geometry 
     gdf_pixels['geometry']=df_poly['poly']

--- a/xagg/diag.py
+++ b/xagg/diag.py
@@ -1,0 +1,142 @@
+
+import xarray as xr
+import numpy as np 
+import geopandas as gpd
+import xagg as xa
+import warnings
+from cartopy import crs as ccrs
+from matplotlib import pyplot as plt
+import matplotlib as mpl
+import shapely
+
+from . core import create_raster_polygons
+
+
+def diag_fig(wm,poly_id,pix_overlap_info,
+	 cmap='magma_r',
+	  max_title_depth = 5,
+	   fig=None,ax=None):
+	""" Create a diagnostic figure showing overlap between pixels and a given polygon
+
+	Parameters
+    ---------------
+    wm : :class:`xagg.classes.weightmap`
+        the output to :func:`xagg.core.get_pixel_overlaps`
+
+    poly_id : int, list, or dict
+      	which polygon to plot. If `int`, then just the polygon in that indexed row of `wm.agg`
+      	is plotted. If `list` of `int`s, then those polygons are plotted. If dict, then all
+      	matches in the geodataframe are plotted (e.g., `poly_id = {'adm1_code':'URY-8'}`). 
+
+    pix_overlap_info : `xarray.classes.dataset.Dataset`, `xarray.classes.dataarray.DataArray`, 
+    				   or the output to `xa.core.create_raster_polygons`
+    	if `ds` or `da`: the original dataset used to calculate the `wm`; needs to be re-entered 
+    					 here because `wm` does not keep the original pixel polygons 
+    	Otherwise, put in the output to `xa.core.create_raster_polygons(ds)`
+
+    cmap : str, by default 'magma_r'
+    	colormap, must be the name of a matplotlib-recognized colormap
+
+	max_title_depth : int, by default 5
+		if only showing one polygon, then the plot title is `', '.join()`, called on the 
+		first `max_title_depth` columns of `wm.agg` that aren't added by `xagg`
+
+	fig : `mpl.figure.Figure` or None, by default None
+		if not None, then this figure handle is used
+
+	ax : `mpl.axis.Axis` or None, by default None
+		if not None, then this axis handle is used
+    
+    Returns
+    ---------------
+    fig,ax : the matplotlib figure, axis handles
+
+	"""
+
+	#---------- Setup ----------
+	if type(poly_id) == int:
+	    poly_idx = [poly_id]
+	elif type(poly_id) == dict:
+	    poly_idx = list((wm.agg.loc[np.prod(np.array([wm.agg[k] == v for k,v in poly_id.items()]),axis=0).astype(bool),:].
+	                index.values))
+	elif type(poly_id) == list:
+	    if not np.all([type(k) == int for k in poly_id]):
+	        raise TypeError('If using list polygon ids, all list members must be integers corresponding to polygon idxs in `wm.agg`.')
+	    poly_idx = poly_id
+
+	# Get pixel polygons/overlaps, if necessary
+	if ((type(pix_overlap_info) == xr.core.dataset.Dataset)
+	     or (type(pix_overlap_info) == xr.core.dataarray.DataArray)):
+	    pix_polys = create_raster_polygons(pix_overlap_info)
+	else:
+	    pix_polys = pix_overlap_info
+
+	# Get which polygon to plot
+	plot_poly = [wm.geometry[idx] for idx in poly_idx]
+	plot_overlap = [wm.agg.iloc[idx,:] for idx in poly_idx]
+
+	# Get pixels overlapping with the desired polygon
+	pix_polys = [pix_polys['gdf_pixels'].loc[overlaps['pix_idxs']]
+	             for overlaps in plot_overlap]
+
+	# Get colors for relative overlap
+	for idx in np.arange(0,len(pix_polys)):
+	    pix_polys[idx]['rel_area'] = plot_overlap[idx]['rel_area'][0].values
+	    pix_polys[idx]['color'] = [tuple(x) for x in plt.get_cmap(cmap)(pix_polys[idx]['rel_area'] / 
+	                                                               pix_polys[idx]['rel_area'].max())]
+
+
+	#---------- Plot ----------
+	if fig == None:
+	    fig = plt.figure()
+
+	if ax == None:
+	    # Create sample figure, centered on polygon centroid
+	    ax = plt.subplot(projection=ccrs.PlateCarree(central_longitude=[k for k in 
+	                                                                    gpd.GeoDataFrame(geometry=[poly.centroid for poly in plot_poly]).dissolve().centroid.values[0].coords][0][0]))
+
+	# Plot polygon
+	for idx in np.arange(0,len(plot_poly)):
+	    if type(plot_poly[idx]) == shapely.geometry.polygon.Polygon:
+	        plt.plot(*plot_poly[idx].exterior.xy,transform=ccrs.PlateCarree(),
+	                  color='tab:green',linewidth=1)
+	    else:
+	         [plt.plot(*k.exterior.xy,transform=ccrs.PlateCarree(),
+	                  color='tab:green',linewidth=1) for k in plot_poly[idx].geoms] #.geoms
+
+	# Add reference coastlines
+	ax.coastlines(color='grey')
+
+	# Add pixels, transparent, but colored by overlap
+	for idx in np.arange(0,len(plot_poly)):
+	    pix_polys[idx].plot(color=pix_polys[idx].color,transform=ccrs.PlateCarree(),ax=ax,
+	    					alpha=0.8)
+
+	#------- Annotate -------
+	# Title
+	if len(plot_overlap) == 1:
+	    ax.set_title('Poly #'+str(poly_idx[0])+': '+
+	             '; '.join([str(plot_overlap[0][k]) for k in plot_overlap[0].index 
+	                        if k not in ['poly_idx','rel_area','pix_idxs','coords']][0:max_title_depth]))
+	else:
+	    ax.set_title('Poly #s: '+', '.join([str(k) for k in poly_idx]))
+
+	# Colorbar
+	fig.subplots_adjust(right=0.825)
+	cax = fig.add_axes([0.875, 0.15, 0.025, 0.7])
+	if len(plot_overlap) == 1:
+	    clabel = 'Overlap area (relative to largest pixel overlap)'
+	else:
+	    clabel = ('Overlap area (relative to largest pixel overlap,\n'+
+	              'recalculated for each polygon; so they may not be\ndirectly comparable'+
+	              ' across polygons)')
+	    
+	cb1 = mpl.colorbar.ColorbarBase(ax=cax, cmap=cmap,
+	                                norm=mpl.colors.Normalize(vmin=0, vmax=1),
+	                                orientation='vertical',
+	                                label = clabel)
+
+
+	# Gridlines
+	gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=['x','y','bottom','left'],
+	                  linewidth=1, color='gray', alpha=0.5, linestyle=':')

--- a/xagg/export.py
+++ b/xagg/export.py
@@ -51,7 +51,8 @@ def export_weightmap(wm_obj,fn,overwrite=False):
             # only affect the testing routines, but setting this here
             # to be explicit 
             wm_obj.weights.astype(object).to_csv(fn+'/'+re.split('\/',fn)[-1]+'_weights.csv')
-    except:
+    except RuntimeError as error:
+        print(error)
         # Remove files that have already been generated, to make 
         # sure no flawed files are floating around. 
         shutil.rmtree(fn)

--- a/xagg/export.py
+++ b/xagg/export.py
@@ -35,13 +35,22 @@ def export_weightmap(wm_obj,fn,overwrite=False):
         with warnings.catch_warnings():
             # Catch performance warning about pickling
             warnings.filterwarnings('ignore')
-            df_out.to_hdf(fn+'/'+re.split('\/',fn)[-1]+'.h5','wm')
+            df_out.to_hdf(fn+'/'+re.split('/',fn)[-1]+'.h5','wm')
 
         ###### Save source grid
         for k in wm_obj.source_grid:
             # Adding v to variable (i.e., 'latv', 'lonv') needed 
             # because of the multi-index being used here 
-            wm_obj.source_grid[k].reset_index('loc').to_dataset(name=k+'v').to_netcdf(fn+'/'+re.split('\/',fn)[-1]+'_'+k+'.nc')
+            source_grid_tmp = wm_obj.source_grid[k].reset_index('loc').to_dataset(name=k+'v')
+
+            # Replicate dataset, to avoid xarray bug stemming from 
+            # Pandas MultiIndex testing... 
+            source_grid_tmp = source_grid_tmp.reset_coords()
+            source_grid_tmp = xr.Dataset({k:([d for d in v.sizes],v.values) for k,v in source_grid_tmp.items()})
+            source_grid_tmp = source_grid_tmp.set_coords([d for d in source_grid_tmp if d not in ['loc', k+'v']])
+
+            # Save
+            source_grid_tmp.to_netcdf(fn+'/'+re.split('/',fn)[-1]+'_'+k+'.nc')
 
         ###### Save weights
         # (If weights == 'nowghts', then no file to load)
@@ -50,7 +59,7 @@ def export_weightmap(wm_obj,fn,overwrite=False):
             # don't change the general type of the frame. This may
             # only affect the testing routines, but setting this here
             # to be explicit 
-            wm_obj.weights.astype(object).to_csv(fn+'/'+re.split('\/',fn)[-1]+'_weights.csv')
+            wm_obj.weights.astype(object).to_csv(fn+'/'+re.split('/',fn)[-1]+'_weights.csv')
     except RuntimeError as error:
         print(error)
         # Remove files that have already been generated, to make 

--- a/xagg/wrappers.py
+++ b/xagg/wrappers.py
@@ -80,6 +80,9 @@ def pixel_overlaps(ds,gdf_in,
       print('creating polygons for each pixel...')
     if subset_bbox:
         pix_agg = create_raster_polygons(ds,subset_bbox=gdf_in,weights=weights)
+        if not silent:
+          if pix_agg['gdf_pixels'].empty:
+            warnings.warning('Bounding box around polygon(s) from `gdf_in` includes no grid cells in `ds`...')
     else:
         pix_agg = create_raster_polygons(ds,subset_bbox=None,weights=weights)
     


### PR DESCRIPTION
Major changes
------------------
Closes #51 by:
- Updating `create_raster_polygons()` such that it splits antimeridian-crossing grid cells into two components of a MultiPolygon, to be in line with GeoJSON conventions (inspired by the solution in https://github.com/gadomski/antimeridian). `shapely` does not see any CRS information and therefore treats -180:180 as a number line; splitting Polygons at the antimeridian is a workaround for this. 
- Updating `get_bnds()` to correctly produce lat/lon bounds for pixels close to the antimeridian, with a handful of new tests for edge cases

Minor changes
------------------
- Adds `NoOverlapError` for when polygons do not overlap with any grid cells in the sample
- `xa.fix_ds()` now only sorts values when a check sees them to be unsorted - this is to avoid loading into memory when not needed (since `xa.fix_ds()` is used outside of `xagg` as well)
- Changes `ds.dims.keys()` to `ds.sizes()` references to avoid warnings