### PR TITLE
Remove explicit dependency on `xesmf`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'numpy',
         'scipy',
@@ -28,9 +28,7 @@ setup(
         'netcdf4',
         'geopandas>=0.12.0',
         'shapely',
-	'tables',
-        'xesmf>=0.7.1',
+	    'tables',
         'cf_xarray>=0.5.1',
-        'esmpy>=8.1.0',
 	 ],
 )

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -47,7 +47,7 @@ class weightmap(object):
         try: 
             from . diag import diag_fig
         except ImportError:
-            raise ImportError('`wm.diag_fig()` separately requires `cartopy` and `matplotlib` to function; make sure these are installed first.')
+            raise ImportError('`wm.diag_fig()` separately requires `cartopy`, `matplotlib`, and `cmocean` to function; make sure these are installed first.')
 
         
         # Plot diagnostic figure

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -155,7 +155,13 @@ def process_weights(ds,weights=None,target='ds',silent=False):
             # Import xesmf here to allow the code to work without it (it 
             # often has dependency issues and isn't necessary for many 
             # features of xagg)
-            import xesmf as xe
+            try:
+                import xesmf as xe
+            except ImportError:
+                raise ImportError('If the `weights` grid and the `ds` grid are different, '+
+                                 '`xesmf` is needed for `xagg` to regrid them to match; however, '+
+                                 '`xesmf` is not installed. Either install `xesmf` or '+
+                                 'manually regrid them to match each other.')
             if target == 'ds':
                 if not silent:
                     print('regridding weights to data grid...')


### PR DESCRIPTION
`xesmf` will now only be imported if weights need to be regridded

`xesmf` is no longer required for installation
`esmpy` is no longer required for installation

Also added `cmocean` to list of optional dependencies required for `diag_fig()`