### PR TITLE
Add ability to set module-wide defaults for silencing, backend aggregation algorithm  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 # xagg /wm/ directories created during docs processing
 wm/
 docs/notebooks/wm/
+wm_export_test/
+
 
 # C extensions
 *.so

--- a/docs/source/notebooks/base_run.ipynb
+++ b/docs/source/notebooks/base_run.ipynb
@@ -608,7 +608,7 @@
    "metadata": {},
    "source": [
     "## Aggregate\n",
-    "Now, aggregate the gridded variable in `ds` onto the polygons in `gdf`. Use the option `silent=True` if you'd like to suppress the status updates. "
+    "Now, aggregate the gridded variable in `ds` onto the polygons in `gdf`. Use the option `silent=True` if you'd like to suppress the status updates, or set it as a default using `xa.set_defaults(silent=True)`. "
    ]
   },
   {

--- a/docs/source/notebooks/full_run.ipynb
+++ b/docs/source/notebooks/full_run.ipynb
@@ -148,6 +148,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d2e7bd60-7859-45e2-9c2a-de73d0a44833",
+   "metadata": {},
+   "source": [
+    "In general, we can suppress these status updates using:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6855fba5-e6d4-4410-8072-37b091c67b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with xa.set_options(silent=True):\n",
+    "    weightmap = xa.pixel_overlaps(ds,gdf,weights=ds_pop.pop)\n",
+    "\n",
+    "# Or, to set as a default for the whole session, \n",
+    "xa.set_options(silent=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2e6c1fd7-a2d6-4ea8-8c38-441b62247a3e",
    "metadata": {},
    "source": [
@@ -354,7 +376,9 @@
    ],
    "source": [
     "# Aggregate\n",
-    "aggregated = xa.aggregate(ds,weightmap)"
+    "aggregated = xa.aggregate(ds,weightmap)\n",
+    "\n",
+    "# as before, use with xa.set_defaults(silent=True) to silence output. "
    ]
   },
   {
@@ -1033,7 +1057,9 @@
     "\n",
     "Other dimensions (e.g. `time`) are kept as they were originally in the grid variable.\n",
     "\n",
-    "Fields in the inputted polygons (e.g., FIPS codes for the US Counties shapefile used here) are saved as additional variables. Attributes from the original `xarray` structure are kept. "
+    "Fields in the inputted polygons (e.g., FIPS codes for the US Counties shapefile used here) are saved as additional variables. Attributes from the original `xarray` structure are kept. \n",
+    "\n",
+    "Note that in all exports, if `xa.set_defaults(silent=False)`, a status update will be given when the file has successfully been exported. "
    ]
   },
   {

--- a/docs/source/tips.rst
+++ b/docs/source/tips.rst
@@ -4,15 +4,20 @@ Tips
 Silencing status updates
 ---------------------------------------
 
-To silence status updates to standard out, use the ``silent=True`` flag::
+To silence status updates to standard out, set ``silent=True``::
 
    import xagg as xa
+   xa.set_defaults(silent=True)
 
-   # Get overlap between pixels and polygons
-   weightmap = xa.pixel_overlaps(ds,gdf,silent=True)
+You can also silence a single operation using ``with``::
 
-   # Aggregate data in [ds] onto polygons
-   aggregated = xa.aggregate(ds,weightmap,silent=True)
+   # Calculate weightmaps without status updates
+   with xa.set_defaults(silent=True):
+      weightmap = xa.pixel_overlaps(ds,gdf)
+
+Note that the `silent=True` option in individual functions will be
+slowly deprecated over the next few versions in favor of using one of
+the two options above.
 
 Saving weights file 
 ---------------------------------------
@@ -38,11 +43,13 @@ Speed up overlap calculation
 ---------------------------------------
 At the expense of increased memory usage, processing may be sped up using an alternate calculation method (``impl='dot_product'``) :: 
 
-   # Get overlap between pixels and polygons
-   weightmap = xa.pixel_overlaps(ds,gdf,impl='dot_product')
+   import xagg as xa
+   # Set dot_product as default backend implementation 
+   xa.set_defaults(impl='dot_product')
 
-   # Aggregate data in [ds] onto polygons
-   aggregated = xa.aggregate(ds,weightmap,impl='dot_product')
+Note that the `impl=dot_product` option in individual functions will be
+slowly deprecated over the next few versions in favor of using the option
+setting approach above (or using ``with xa.set_defaults(impl='dot_product'):`` ).
 
 Create diagnostic figure to inspect raster/polygon overlaps 
 ------------------------------------------------------------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -16,11 +16,6 @@ build:
 conda:
     environment: docs/docenvironment.yml
 
-#python:
-#   version: 3.12
-#   install:
-#      - method: setuptools
-#        path: package
 sphinx:
   fail_on_warning: False
   configuration: docs/source/conf.py

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -7,8 +7,11 @@ import copy
 from geopandas import testing as gpdt
 from unittest import TestCase
 from shapely.geometry import Polygon
+from unittest.mock import patch
+from io import StringIO
 
-from xagg.wrappers import (pixel_overlaps)
+from xagg.wrappers import pixel_overlaps
+from xagg.options import set_options
 
 
 ##### pixel_overlaps() tests #####
@@ -92,3 +95,48 @@ def test_pixel_overlaps_dataarray_wname():
 	assert np.allclose([v for v in df0.rel_area],[v for v in df_compare.rel_area])
 	assert np.allclose([v for v in df0.pix_idxs],[v for v in df_compare.pix_idxs])
 	assert np.allclose([v for v in df0.coords],[v for v in df_compare.coords])
+
+##### pixel_overlaps() silent tests #####
+@patch('sys.stdout', new_callable=StringIO)
+def test_pixel_overlaps_silent_true(mock_stdout):
+
+	# Create dataarray
+	da = xr.DataArray(data=np.array([[0,1],[2,3]]),
+					  coords={'lat':(['lat'],np.array([0,1])),
+							'lon':(['lon'],np.array([0,1]))},
+					  dims=['lon','lat'],
+					  name='tas')
+
+	# Create polygon covering one pixel
+	gdf_test = {'name':['test'],
+				'geometry':[Polygon([(-0.5,-0.5),(-0.5,0.5),(0.5,0.5),(0.5,-0.5),(-0.5,-0.5)])]}
+	gdf_test = gpd.GeoDataFrame(gdf_test,crs="EPSG:4326")
+
+	# Calculate pixel_overlaps through the wrapper function
+	with set_options(silent=True):
+		wm = pixel_overlaps(da,gdf_test)
+
+	# Check that nothing was printed
+	assert mock_stdout.getvalue() == ''
+
+
+@patch('sys.stdout', new_callable=StringIO)
+def test_pixel_overlaps_silent_false(mock_stdout):
+	# Create dataarray
+	da = xr.DataArray(data=np.array([[0,1],[2,3]]),
+					  coords={'lat':(['lat'],np.array([0,1])),
+							'lon':(['lon'],np.array([0,1]))},
+					  dims=['lon','lat'],
+					  name='tas')
+
+	# Create polygon covering one pixel
+	gdf_test = {'name':['test'],
+				'geometry':[Polygon([(-0.5,-0.5),(-0.5,0.5),(0.5,0.5),(0.5,-0.5),(-0.5,-0.5)])]}
+	gdf_test = gpd.GeoDataFrame(gdf_test,crs="EPSG:4326")
+
+	# Calculate pixel_overlaps through the wrapper function
+	with set_options(silent=False):
+		wm = pixel_overlaps(da,gdf_test)
+
+	# Check that nothing was printed
+	assert mock_stdout.getvalue() != ''

--- a/xagg/__init__.py
+++ b/xagg/__init__.py
@@ -5,3 +5,4 @@
 from .wrappers import pixel_overlaps
 from .auxfuncs import (normalize,fix_ds,get_bnds,subset_find)
 from .core import (aggregate,read_wm)
+from .options import get_options, set_options

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -2,6 +2,7 @@ from .export import (prep_for_nc,prep_for_csv,output_data,export_weightmap)
 import warnings
 import os
 import re
+from .options import get_options
 
 try:
     import cartopy 
@@ -91,56 +92,63 @@ class aggregated(object):
         return df_out
 
     # Export functions
-    def to_netcdf(self,fn,loc_dim='poly_idx',silent=False):
+    def to_netcdf(self,fn,loc_dim='poly_idx',silent=None):
         """ Save as netcdf
 
         Parameters
         -----------------
         
-        fn : str
+        fn : :py:class:`str`
             The target filename
 
-        loc_dim : str, by default `'poly_idx'`
+        loc_dim : :py:class:`str`, by default `'poly_idx'`
             What to name the polygon dimension
 
-        silent : bool, by default False
+        silent : :py:class:`bool`, by default False
             If `True`, silences standard out
 
         """
+        if silent is None:
+            silent = get_options()['silent']
+
         output_data(self,
                    output_format = 'netcdf',
                    output_fn = fn,
                    loc_dim = loc_dim,
                    silent = silent)
         
-    def to_csv(self,fn,silent=False):
+    def to_csv(self,fn,silent=None):
         """ Save as csv
 
         Parameters
         -----------------
         
-        fn : str
+        fn : :py:class:`str`
             The target filename
 
-        silent : bool, by default False
+        silent : :py:class:`bool`, by default False
             If `True`, silences standard out
 
         """
+        if silent is None:
+            silent = get_options()['silent']
         output_data(self,
                    output_format = 'csv',
                    output_fn = fn,
                    silent=silent)
         
-    def to_shp(self,fn,silent=False):
+    def to_shp(self,fn,silent=None):
         """ Save as shapefile
 
-        fn : str
+        fn : :py:class:`str`
             The target filename
 
-        silent : bool, by default False
+        silent : :py:class:`bool`, by default False
             If `True`, silences standard out
             
         """
+        if silent is None:
+            silent = get_options()['silent']
         output_data(self,
                    output_format = 'shp',
                    output_fn = fn,

--- a/xagg/options.py
+++ b/xagg/options.py
@@ -1,0 +1,110 @@
+# Partially adapted from xarray's xr.core.options
+# NB: In a future version, setting `impl` and `silent`
+# in individual function calls should be deprecated 
+# in favor of setting global defaults or using 
+# with blocks. 
+from typing import TypedDict
+
+# Create class specifying the needed
+# type of each option
+class T_Options(TypedDict):
+	silent : bool
+	impl : str
+
+# Set default options. Defining it in
+# the module makes it global to the module
+# (as opposed to within a function, where
+# it should only be local to the function)
+OPTIONS: T_Options = {
+	'silent' : False,
+	'impl' : 'for_loop'
+}
+
+
+# Options for the backend implementation
+_IMPL_OPTIONS = frozenset(['for_loop','dot_product'])
+
+# Each item of this dictionary is a test for whether a
+# modification for the corresponding option was correctly
+# set. I.e., "silent" can only be True or False, so the
+# 'silent' dict option here tests for whether it's a bool. 
+_VALIDATORS = {
+	'silent': lambda value: isinstance(value, bool),
+	'impl': _IMPL_OPTIONS.__contains__,
+}
+
+# Define options class
+class set_options: 
+	""" Set options for xagg.
+
+	Parameters
+	----------
+	silent : bool, by default ``False``
+		If True, then status updates are suppressed 
+
+	impl : str, by default ``"for_loop"``
+		Sets backend algorithm, can be 
+
+		* ``for_loop``: slower, but lower memory use
+		* ``dot_product``: faster, but higher memory use
+
+	"""
+	
+	def __init__(self, **kwargs):
+		# Keep track of changed options, to be able to change
+		# them back if used in a `with` block (see __exit__ below)
+		self.old = {}
+
+		for k, v in kwargs.items():
+			# Check to make sure the option you're looking to change
+			# is an option changeable by set_options()
+			if k not in OPTIONS:
+				raise ValueError(
+					f"argument name {k!r} is not in the set of valid options {set(OPTIONS)!r}"
+				)
+
+			# Check to make sure the new value of the option is 
+			# acceptable
+			if k in _VALIDATORS and not _VALIDATORS[k](v):
+				if k == "impl":
+					expected = f"Expected one of {_IMPL_OPTIONS!r}"
+				else:
+					expected = ""
+				raise ValueError(
+					f"option {k!r} given an invalid value: {v!r}. " + expected
+				)
+			# Note original value of changed options, to reset
+			# defaults in the __exit__ block below
+			self.old[k] = OPTIONS[k]
+		# Update OPTIONS 
+		self._apply_update(kwargs)
+
+	def _apply_update(self, options_dict):
+		""" Update OPTIONS """
+		OPTIONS.update(options_dict)
+
+	# This allows use with "with set_options(...):"
+	# See e.g., https://stackoverflow.com/questions/1984325/explaining-pythons-enter-and-exit
+	def __enter__(self):
+		return
+	# Resets to the original OPTIONS at the end 
+	# of a `with` block
+	def __exit__(self, type, value, traceback):
+		self._apply_update(self.old)
+
+
+def get_options():
+	"""
+	Get module-wide options for xagg.
+
+	See Also
+	----------
+	:py:meth:`set_options`
+
+	"""
+	# Returning a copy, to make sure no unintended changes to
+	# the output of get_options() trickle down to anything
+	# else that uses the variable
+	return OPTIONS.copy()
+
+	

--- a/xagg/wrappers.py
+++ b/xagg/wrappers.py
@@ -3,13 +3,14 @@ import xarray as xr
 import copy
 
 from . core import (create_raster_polygons,get_pixel_overlaps)
+from . options import get_options
 
 
 def pixel_overlaps(ds,gdf_in,
                    weights=None,weights_target='ds',
                    subset_bbox = True,
-                   impl='for_loop',
-                   silent=False):
+                   impl=None,
+                   silent=None):
     """ Wrapper function for determining overlaps between grid and polygon
     
     For a geodataframe `gdf_in`, takes an `xarray` structure `ds` (Dataset or 
@@ -50,11 +51,12 @@ def pixel_overlaps(ds,gdf_in,
       a `NotImplementedError`)
 
     impl : :class:`str`, optional, default = ``'for_loop'``
+      (set by :py:meth:`xa.set_options`)
       whether to use the ``'for_loop'`` or ``'dot_product'``
       methods for aggregating; the former uses less memory,
       the latter may be faster in certain circumstances
 
-    silent : :py:class:`bool`, default = `False`
+    silent : :py:class:`bool`, default = `False` (set by :py:meth:`xa.set_options`)
         if True, then no status updates are printed to std out
    
     Returns
@@ -64,6 +66,11 @@ def pixel_overlaps(ds,gdf_in,
       input into :func:`xagg.core.aggregate`. 
     
     """
+    if impl is None:
+      impl = get_options()['impl']
+    if silent is None:
+      silent = get_options()['silent']
+
     # Create deep copy of gdf to ensure the input gdf doesn't 
     # get modified
     gdf_in = copy.deepcopy(gdf_in)


### PR DESCRIPTION
Main changes
============
- Implements a way to set global defaults, updates tests, docs to match

Now, `xa.set_defaults()` can be used, either on its own or in a `with` block, to set `silent=True/False` or `impl='for_loop'/'dot_product'`. 

Now truly fixes #55 

Minor changes
============
- `.gitignore` now ignores temporary files created during export tests