### PR TITLE
Diag fig fix

### DIFF
--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -188,11 +188,10 @@ def test_to_netcdf(agg=agg):
 	               			coords = {'poly_idx':(('poly_idx'),[0]),
 	                         'run':(('run'),[0,1])})
 
-		# Load
-		ds_out = xr.open_dataset('test.nc')
-
-		# Test
-		xr.testing.assert_allclose(ds_ref,ds_out)
+		# Load and Test
+		with xr.open_dataset('test.nc') as ds_out:
+			xr.testing.assert_allclose(ds_ref,ds_out)
+		
 	finally:
 		# Remove test export file 
 		os.remove('test.nc')

--- a/xagg/diag.py
+++ b/xagg/diag.py
@@ -62,9 +62,15 @@ def diag_fig(wm,poly_id,pix_overlap_info,
 	        raise TypeError('If using list polygon ids, all list members must be integers corresponding to polygon idxs in `wm.agg`.')
 	    poly_idx = poly_id
 
+    # Turn into dataset if dataarray
+    if type(pix_overlap_info)==xr.core.dataarray.DataArray:
+      if pix_overlap_info.name is None:
+        pix_overlap_info = pix_overlap_info.to_dataset(name='var')
+      else:
+        pix_overlap_info = pix_overlap_info.to_dataset()
+
 	# Get pixel polygons/overlaps, if necessary
-	if ((type(pix_overlap_info) == xr.core.dataset.Dataset)
-	     or (type(pix_overlap_info) == xr.core.dataarray.DataArray)):
+	if ((type(pix_overlap_info) == xr.core.dataset.Dataset):
 	    pix_polys = create_raster_polygons(pix_overlap_info)
 	else:
 	    pix_polys = pix_overlap_info


### PR DESCRIPTION
Fixing diag_fig to accept an xarray data array (in addition to dataset). The documentation says this is possible but it is not due to the direct call to create_raster_polygons which skips the wrapper where data arrays are converted to datasets. I've copied the dataset conversion lines to diag_fig from the pixel_overlaps wrapper. 

I ran the tests and found 4 fails but they are unrelated to my edits as the fails were present beforehand. This PR includes a fix for two of the fails. They were related to trying to delete the test.nc temporary file while it is open in test_to_netcdf.

The other two fails are related to precision/tolerance, which I didn't look into. (platform win32 -- Python 3.12.4, pytest-8.2.2, pluggy-1.5.0)

```
FAILED tests/test_export.py::test_to_dataframe - AssertionError: MultiIndex level [0] are different
FAILED tests/test_export.py::test_to_dataframe_renamelocdim - AssertionError: MultiIndex level [0] are different
```
