### PR TITLE
Fixes triggered regridding on identical grids issue

### DIFF
--- a/=
+++ b/=
@@ -1,0 +1,20 @@
+conda-forge/osx-64                                          Using cache
+conda-forge/noarch                                          Using cache
+pkgs/main/osx-64                                            Using cache
+pkgs/main/noarch                                            Using cache
+pkgs/r/osx-64                                               Using cache
+pkgs/r/noarch                                               Using cache
+
+Looking for: ['xesmf', '0.7.1']
+
+
+Pinned packages:
+  - python 3.13.*
+
+
+Could not solve for environment specs
+Encountered problems while solving:
+  - nothing provides requested 0.7.1
+
+The environment can't be solved, aborting the operation
+

--- a/=0.7.1
+++ b/=0.7.1
@@ -1,0 +1,37 @@
+Transaction
+
+  Prefix: /Users/kevinschwarzwald/opt/anaconda3/envs/xagg_test2
+
+  Updating specs:
+
+   - xesmf
+   - ca-certificates
+   - certifi
+   - openssl
+
+
+  Package              Version  Build       Channel                Size
+─────────────────────────────────────────────────────────────────────────
+  Upgrade:
+─────────────────────────────────────────────────────────────────────────
+
+  - ca-certificates  2024.8.30  h8857fd0_0  conda-forge                
+  + ca-certificates  2024.9.24  hecd8cb5_0  pkgs/main/osx-64     Cached
+
+  Summary:
+
+  Upgrade: 1 packages
+
+  Total download: 0 B
+
+─────────────────────────────────────────────────────────────────────────
+
+
+Confirm changes: [Y/n] 
+Looking for: ['xesmf']
+
+
+Pinned packages:
+  - python 3.13.*
+
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,6 +110,30 @@ def test_process_weights_close_weights():
 	# Check if weights were correctly added to ds
 	xr.testing.assert_allclose(ds_compare,ds_t)
 
+def test_process_weights_missingoverlap_warning():
+	# Make sure a warning comes up if the weights file doesn't span
+	# the whole `ds` input's geography
+
+	# Make sure weights that are within `np.allclose` but not exactly
+	# the same grid as the input ds are correctly allocated
+	# Robustness against floating point differences in grids)
+	ds = xr.Dataset(coords={'lat':(['lat'],np.arange(-5,5)),
+							'lon':(['lon'],np.arange(-5,5))})
+
+	weights = xr.DataArray(data=np.array([[0,1],[2,3]]),
+							dims=['lat','lon'],
+							coords=[np.array([0,1]),
+									np.array([0,1])])
+
+	# Test that warning is raised
+	with pytest.warns(UserWarning):
+		ds_t,weights_info = process_weights(ds,weights=weights)
+
+	# Test now that it doesn't raise when they do overlap
+	ds = ds.sel(lat=[0,1],lon=[0,1])
+	with warnings.catch_warnings():
+		warnings.simplefilter("error")
+		ds_t,weights_info = process_weights(ds,weights=weights)
 
 ##### create_raster_polygons() tests #####
 def test_create_raster_polygons_basic():
@@ -201,6 +225,24 @@ def test_create_raster_polygons_at180():
 		wm_out = get_pixel_overlaps(gdf_test,pix_agg)
 
 
+def test_create_raster_polygons_weightsbbox():
+	# Make sure that the weights and ds are subset equally / correctly
+	# To test for an error in which if subset_bbox is not None, then 
+	# only the ds and not the weights are subset, causing a regridding
+	# call and a corresponding error (if xesmf is not installed) or a 
+	# way out of sample bad regridding if xesmf is installed!
+	ds = xr.Dataset({'test':(('lat','lon'),np.random.rand(10,20)),
+		 			 'weights':(('lat','lon'),np.random.rand(10,20))},
+		           coords = {'lat':(['lat'],np.arange(-5,5)),
+		                     'lon':(['lon'],np.arange(-10,10))})
+
+	# Create polygon covering multiple pixels
+	gdf = {'name':['test'],
+				'geometry':[Polygon([(0,0),(0,1),(1,1),(1,0),(0,0)])]}
+	gdf = gpd.GeoDataFrame(gdf,crs="EPSG:4326")
+
+	pix_agg = create_raster_polygons(ds,weights=ds.test,
+									 subset_bbox=gdf)
 
 ##### get_pixel_overlaps() tests #####
 # build raster polygons from a simple 2x2x3 grid of lat/lon/time pixels

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 import copy
 import pandas as pd
 import numpy as np

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -127,8 +127,10 @@ def test_process_weights_missingoverlap_warning():
 									np.array([0,1])])
 
 	# Test that warning is raised
-	with pytest.warns(UserWarning):
-		ds_t,weights_info = process_weights(ds,weights=weights)
+	# (if no xesmf, then it fails anyways, tested separately)
+	if _has_xesmf:
+		with pytest.warns(UserWarning):
+			ds_t,weights_info = process_weights(ds,weights=weights)
 
 	# Test now that it doesn't raise when they do overlap
 	ds = ds.sel(lat=[0,1],lon=[0,1])

--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -14,7 +14,7 @@ try:
     import cmocean
     _has_plotpckgs=True
 except ImportError:
-	# To be able to test the rest with environments without xesmf
+	# To be able to test the rest with environments without plotting functions
 	_has_plotpckgs=False
 
 ##### diag_fig() tests #####

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -323,10 +323,6 @@ def create_raster_polygons(ds,
             bbox_thresh = grid_dist*2. # then set threshold to twice grid size, avoids huge subsets for high res grids
             ds = ds.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
                         lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
-            if weights is not None:
-                # Also subset weights (which should now match the ds grid after `process_weights`)
-                weights = weights.sel(lon=slice(subset_bbox.total_bounds[0]-bbox_thresh,subset_bbox.total_bounds[2]+bbox_thresh),
-                                  lat=slice(subset_bbox.total_bounds[1]-bbox_thresh,subset_bbox.total_bounds[3]+bbox_thresh))
         else:
             warnings.warn('[subset_bbox] is not a geodataframe; no mask by polygon bounding box used.')
             

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -500,7 +500,7 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl=None):
     else:
         if impl=='dot_product':
             # Get relative area of each pixel
-            overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area,include_groups=False)
+            overlaps = overlaps.groupby('poly_idx',group_keys=False)[overlaps.columns.tolist()].apply(find_rel_area,include_groups=False)
             overlaps['lat'] = overlaps['lat'].astype(float)
             overlaps['lon'] = overlaps['lon'].astype(float)
 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -500,7 +500,7 @@ def get_pixel_overlaps(gdf_in,pix_agg,impl=None):
     else:
         if impl=='dot_product':
             # Get relative area of each pixel
-            overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area)
+            overlaps = overlaps.groupby('poly_idx',group_keys=False).apply(find_rel_area,include_groups=False)
             overlaps['lat'] = overlaps['lat'].astype(float)
             overlaps['lon'] = overlaps['lon'].astype(float)
 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -162,10 +162,12 @@ def process_weights(ds,weights=None,target='ds',silent=None):
         if get_options()['nan_to_zero_regridding']:
             weights = weights.where(~np.isnan(weights),0)
 
+
         # Regrid, if necessary (do nothing if the grids match up to within
         # floating-point precision)
         if ((not ((ds.sizes['lat'] == weights.sizes['lat']) and (ds.sizes['lon'] == weights.sizes['lon']))) or 
             (not (np.allclose(ds.lat,weights.lat) and np.allclose(ds.lon,weights.lon)))):
+
             # Import xesmf here to allow the code to work without it (it 
             # often has dependency issues and isn't necessary for many 
             # features of xagg)
@@ -180,13 +182,12 @@ def process_weights(ds,weights=None,target='ds',silent=None):
             # beyond its boundaries)
             bbox_ds = [ds.lat.min(),ds.lat.max(),ds.lon.min(),ds.lon.max()]
             bbox_wgts = [weights.lat.min(),weights.lat.max(),weights.lon.min(),weights.lon.max()]
-
             if ((bbox_wgts[0]>bbox_ds[0]) or (bbox_wgts[1]<bbox_ds[1]) or
                 (bbox_wgts[2]>bbox_ds[2]) or (bbox_wgts[3]<bbox_wgts[3])):
                 warnings.warn('The `weights` input (bbox latmin, latmax, lonmin, lonmax: '+
-                              ', '.join([str(k).values for k in bbox_wgts])+
+                              ', '.join([str(k.values) for k in bbox_wgts])+
                               ' spans less area than the `ds` input (bbox: '+
-                              ', '.join([str(k).values for k in bbox_ds])+'). Weights beyond '+
+                              ', '.join([str(k.values) for k in bbox_ds])+'). Weights beyond '+
                               ' this bounding box may be set to 0 or incorrectly interpolated.')
 
             if target == 'ds':

--- a/xagg/wrappers.py
+++ b/xagg/wrappers.py
@@ -3,6 +3,7 @@ import xarray as xr
 import copy
 
 from . core import (create_raster_polygons,get_pixel_overlaps)
+from . auxfuncs import fix_ds
 from . options import get_options
 
 


### PR DESCRIPTION
- Moves `process_weights`, which homogenizes `weights` and the input `ds`, from after subsetting to a bounding box to before that process, which prevents regridding to be triggered on otherwise identical `weights` and `ds` grids, if a bounding box is used (which can lead to an error if `xesmf` is not installed)
- Adds a warning if inputted `weights` don't span the entirety of the `ds` (this happens irrespective of the extent of the geodataframe inputted, however, which could lead to spurious warnings if the weight file spans the geodataframe but the `ds` covers a larger area)
- Adds tests to make sure the above warning is correctly triggered and weights and `ds` are jointly subset to bbox correctly.

Closes #86 

