### PR TITLE
add fix_ds to diag_fig call

### DIFF
--- a/tests/test_diag.py
+++ b/tests/test_diag.py
@@ -54,6 +54,16 @@ if _has_plotpckgs:
 		fig,ax=wm.diag_fig({'NAME':'Los Angeles'},ds)
 
 		assert ax.get_title() == 'Poly #2384: Los Angeles; California; 06; 037; 06037'
+
+	def test_diag_fig_nonstandard_dimnames():
+		# Test to make sure this works if the input `ds` has
+		# nonstandard coordinate names
+		# Have to regenerate weightmap from start to really
+		# test
+		ds_rn = ds.rename({'lat':'y','lon':'x'}).copy()
+		wm = pixel_overlaps(ds_rn,gdf)
+		fig,ax=wm.diag_fig(50,ds_rn)
+		
 else:
 	def test_diag_fig_noimport():
 		# Should raise ImportError in the no-plot environment

--- a/xagg/classes.py
+++ b/xagg/classes.py
@@ -3,7 +3,7 @@ import warnings
 import os
 import re
 from .options import get_options,set_options
-from .auxfuncs import subset_find
+from .auxfuncs import subset_find,fix_ds
 
 try:
     import cartopy 
@@ -50,6 +50,9 @@ class weightmap(object):
             from . diag import diag_fig
         except ImportError:
             raise ImportError('`wm.diag_fig()` separately requires `cartopy`, `matplotlib`, and `cmocean` to function; make sure these are installed first.')
+
+        # Standardize input ds coordinates etc.
+        ds = fix_ds(ds)
 
         # Adjust grids between the input ds and the weightmap grid (in case subset to 
         # bbox was used)


### PR DESCRIPTION
- Adds a `xa.fix_ds()` call to `wm.diag_fig()`, which means that the diagnostic figure also works if the input ds is not standardized 
- Closes #85 