### PR TITLE
Bug fixes and optimizations in numba implementation, better partial nan warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 __pycache__/
 *.py[cod]
 
-# Internal test notebooks
+# Internal test notebooks and files
 *test*.ipynb
+*tmp*.py
 
 # xagg /wm/ directories created during docs processing
 wm/

--- a/ci/environment-py3.10.yml
+++ b/ci/environment-py3.10.yml
@@ -16,6 +16,7 @@ dependencies:
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
   - pytables
+  - dask
   ##############
   - pytest
   - pip:

--- a/ci/environment-py3.11.yml
+++ b/ci/environment-py3.11.yml
@@ -16,6 +16,7 @@ dependencies:
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
   - pytables
+  - dask
   ##############
   - pytest
   - pip:

--- a/ci/environment-py3.12.numba.yml
+++ b/ci/environment-py3.12.numba.yml
@@ -17,6 +17,7 @@ dependencies:
   - esmpy >= 8.1.0 
   - pytables
   - numba
+  - dask 
   ##############
   - pytest
   - pip:

--- a/ci/environment-py3.12.plotfuncs.yml
+++ b/ci/environment-py3.12.plotfuncs.yml
@@ -19,6 +19,7 @@ dependencies:
   - cartopy
   - matplotlib
   - cmocean
+  - dask
   ##############
   - pytest
   - pip:

--- a/ci/environment-py3.12.yml
+++ b/ci/environment-py3.12.yml
@@ -16,6 +16,7 @@ dependencies:
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
   - pytables
+  - dask
   ##############
   - pytest
   - pip:

--- a/ci/environment-py3.9.yml
+++ b/ci/environment-py3.9.yml
@@ -16,6 +16,7 @@ dependencies:
   - esmf >= 8.1.0
   - esmpy >= 8.1.0 
   - pytables
+  - dask
   ##############
   - pytest
   - pip:

--- a/tests/test_auxfuncs.py
+++ b/tests/test_auxfuncs.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import xarray as xr
-from xagg.auxfuncs import (normalize,fix_ds,get_bnds,subset_find)
+from xagg.auxfuncs import (normalize,fix_ds,get_bnds,subset_find,_diagnose_nans)
 
 ##### normalize() tests #####
 def test_normalize():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,6 +25,7 @@ except ImportError:
     _has_numba = False
 
 from xagg.core import (process_weights,create_raster_polygons,get_pixel_overlaps,aggregate,NoOverlapError)
+from xagg.auxfuncs import SomeNanWarning
 from xagg.options import set_options
 
 ##### process_weights() tests #####
@@ -607,12 +608,15 @@ def test_aggregate_with_weights(ds=ds):
 	# Get aggregate
 	agg_for = aggregate(ds,wm_for,impl='for_loop')
 	agg_dot = aggregate(ds,wm_dot,impl='dot_product')
+	if _has_numba:
+		agg_num = aggregate(ds,wm_for,impl='numba')
 
 	# Since the "test" for the input ds has [1,8] for the two 
 	# equatorial pixels, the average should just be 4 for timestep 1
 	pd.testing.assert_series_equal(agg_for.agg.test,pd.Series([[[[4,5,6]]]],name='test'))
 	pd.testing.assert_series_equal(agg_dot.agg.test,pd.Series([[[[4,5,6]]]],name='test'))
-
+	if _has_numba:
+		pd.testing.assert_series_equal(agg_num.agg.test,pd.Series([[[[4,5,6]]]],name='test'))
 
 
 def test_aggregate_with_mismatched_grid():
@@ -644,9 +648,13 @@ def test_aggregate_with_mismatched_grid():
 	# Get aggregate
 	agg_for = aggregate(ds,wm_for,impl='for_loop')
 	agg_dot = aggregate(ds,wm_dot,impl='dot_product')
+	if _has_numba:
+		agg_num = aggregate(ds,wm_for,impl='numba')
 
 	pd.testing.assert_series_equal(agg_for.agg.test,pd.Series([[[[18.9999,19.9999,20.9999]]]],name='test'),atol=1e-4)
 	pd.testing.assert_series_equal(agg_dot.agg.test,pd.Series([[[[18.9999,19.9999,20.9999]]]],name='test'),atol=1e-4)
+	if _has_numba:
+		pd.testing.assert_series_equal(agg_num.agg.test,pd.Series([[[[18.9999,19.9999,20.9999]]]],name='test'),atol=1e-4)
 
 
 
@@ -871,6 +879,7 @@ def test_aggregate_with_partialnans():
 						'lon':(['lon'],np.array([0,1])),
 						'bnds':(['bnds'],np.array([0,1])),
 						'time':(['time'],pd.date_range('2019-01-01','2019-01-03'))})
+	# Add some nans in some locations at not all time steps
 	ds['test'] = ds['test'].where(((ds.lon!=1) | (ds.lat!=1) | (ds.time!=pd.to_datetime('2019-01-01'))))
 
 	# get aggregation mapping
@@ -887,12 +896,23 @@ def test_aggregate_with_partialnans():
 	wm_dot = get_pixel_overlaps(gdf,pix_agg,impl='dot_product')
 
 	# Get aggregate
-	with pytest.warns(UserWarning):
+	with pytest.warns(SomeNanWarning):
 		agg_for = aggregate(ds,wm_for,impl='for_loop')
-	with pytest.warns(UserWarning):
+	with pytest.warns(SomeNanWarning):
 		agg_dot = aggregate(ds,wm_dot,impl='dot_product')
 	if _has_numba:
-		agg_num = aggregate(ds,wm_for,impl='numba')
+		with pytest.warns(SomeNanWarning):
+			agg_num = aggregate(ds,wm_for,impl='numba')
+
+def test_aggregate_with_fullnans():
+	# This is a test to make sure that pixels that have no data / are np.nan
+	# are ignored in the final aggregation, and the remaining overlapping
+	# pixels are renormalized
+
+
+def test_aggregate_with_polynans():
+	# This is a test to make sure that regions that are completely outside
+	# of the dataset are nan of the same shape as the others have data
 
 ##### aggregate() silencing tests #####
 # Create polygon covering multiple pixels

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -904,13 +904,13 @@ def test_aggregate_with_partialnans():
 		with pytest.warns(SomeNanWarning):
 			agg_num = aggregate(ds,wm_for,impl='numba')
 
-def test_aggregate_with_fullnans():
+#def test_aggregate_with_fullnans():
 	# This is a test to make sure that pixels that have no data / are np.nan
 	# are ignored in the final aggregation, and the remaining overlapping
 	# pixels are renormalized
 
 
-def test_aggregate_with_polynans():
+#def test_aggregate_with_polynans():
 	# This is a test to make sure that regions that are completely outside
 	# of the dataset are nan of the same shape as the others have data
 

--- a/xagg/auxfuncs.py
+++ b/xagg/auxfuncs.py
@@ -94,6 +94,8 @@ def _diagnose_nans(da,other_dims,
 
 
     '''
+    # Copy, to make sure the original dataarray is untouched
+    da = da.copy()
 
     # Flag if all values of the variable are nan for some specific coordinate
     # along a dimension (this is not per se a problem, but good to have a 
@@ -111,6 +113,7 @@ def _diagnose_nans(da,other_dims,
     # Now, find for which `locs` there are inconsistent nans 
     somenan_flags = {dim:(da.isnull().any(dim = dim) != 
                           da.isnull().all(dim = dim)).any().values
+                         if da.sizes[dim] != 0 else False
                      for dim in other_dims}
 
     # Combine into single dict
@@ -144,15 +147,17 @@ def _warn_ifsomenans(ds,var,dims,
     that info. Basically, can do a [is in] across pix_idxs to flag
     poly_idxs that should optionally be nan in this case 
     '''
+    if type(ds) == xr.core.dataset.Dataset:
+        ds = ds[var].copy()
     
     if _return_somelocs:
         raise NotImplementedError
 
-        nanflags,somelocs = _diagnose_nans(ds[var],other_dims,
+        nanflags,somelocs = _diagnose_nans(ds,dims,
              _return_somelocs=True)
 
     else:
-        nanflags = _diagnose_nans(ds[var],other_dims)
+        nanflags = _diagnose_nans(ds,dims)
 
 
     if (_warn_trigger_partialnan and 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -851,7 +851,7 @@ def aggregate(ds,wm,impl=None,silent=None):
             if ('bnds' not in ds[var].sizes) and ('loc' in ds[var].sizes):
                 if not silent:
                     print('aggregating '+var+'...')
-                agg = xr.merge([xr.apply_ufunc(numba_aggregate,
+                agg = xr.apply_ufunc(numba_aggregate,
                                    ds[var],
                                    idxs.idxs,
                                    idxs.rel_area,
@@ -860,7 +860,6 @@ def aggregate(ds,wm,impl=None,silent=None):
                                    vectorize=True,
                                    dask='parallelized',
                                    output_dtypes = [float]).to_dataset(name=var)
-                                for var in ds if (('bnds' not in ds[var].sizes) and ('loc' in ds[var].sizes))])
 
                 # Trigger computation, otherwise it separately triggers computation
                 # for every poly_idx below, with tremendous overhead 

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -862,6 +862,10 @@ def aggregate(ds,wm,impl=None,silent=None):
                                    output_dtypes = [float]).to_dataset(name=var)
                                 for var in ds if (('bnds' not in ds[var].sizes) and ('loc' in ds[var].sizes))])
 
+                # Trigger computation, otherwise it separately triggers computation
+                # for every poly_idx below, with tremendous overhead 
+                agg = agg.compute()
+
                 # Put in `aggregated` format (TODO: should reform this to remove some of the 
                 # nested lists that are here for some reason)
                 wm.agg[var] = [[[agg[var].sel(poly_idx = idx).values]] for idx in wm.agg.index]

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -732,13 +732,9 @@ def aggregate(ds,wm,impl=None,silent=None):
                 # either has values for each step, or nans for each step - if
                 # there are random nans along non-location dimensions for the 
                 # same grid cell, throw a warning)
-                print('var_array before _warnifsomenans:')
-                print(var_array)
                 _warn_trigger_partialnan=_warn_ifsomenans(var_array,var,other_dims,
                                                             _warn_trigger_partialnan)
 
-                print('var_array after _warnifsomenans:')
-                print(var_array)
 
                 # multiply percent-overlaps by user-supplied weights 
                 weights_and_overlaps = wm.overlap_da * weights

--- a/xagg/core.py
+++ b/xagg/core.py
@@ -732,8 +732,13 @@ def aggregate(ds,wm,impl=None,silent=None):
                 # either has values for each step, or nans for each step - if
                 # there are random nans along non-location dimensions for the 
                 # same grid cell, throw a warning)
+                print('var_array before _warnifsomenans:')
+                print(var_array)
                 _warn_trigger_partialnan=_warn_ifsomenans(var_array,var,other_dims,
                                                             _warn_trigger_partialnan)
+
+                print('var_array after _warnifsomenans:')
+                print(var_array)
 
                 # multiply percent-overlaps by user-supplied weights 
                 weights_and_overlaps = wm.overlap_da * weights
@@ -761,6 +766,8 @@ def aggregate(ds,wm,impl=None,silent=None):
                 data_dict[var] = aggregated_array
 
         ds_combined = xr.Dataset(data_dict)  
+        print('ds_combined:')
+        print(ds_combined)
 
         for var in ds:
             if ('bnds' not in ds[var].sizes) and ('loc' in ds[var].sizes):
@@ -797,7 +804,8 @@ def aggregate(ds,wm,impl=None,silent=None):
                         # either has values for each step, or nans for each step - if
                         # there are random nans along non-location dimensions for the 
                         # same grid cell, throw a warning)
-                        _warn_trigger_partialnan=_warn_ifsomenans(ds,var,other_dims,_warn_trigger_partialnan)
+                        _warn_trigger_partialnan=_warn_ifsomenans(ds,var,other_dims,
+                                                                  _warn_trigger_partialnan)
 
 
                         if not np.isnan(ds[var].isel(loc=wm.agg.iloc[poly_idx,:].pix_idxs)).all(): 


### PR DESCRIPTION
- Closes #91 , making sure the numba implementation allows for the processing of secondary weights. 
- Optimizes the numba implementation to allow better parallelization and much faster processing. Still can't return dask arrays (which may require a drastic rewrite of `wm.agg`), but that may be on the horizon
- Stops frivolous triggers of the partial nan warning when a dimension has coordinates for which all values are nan. Also improves partial nan warning. Outsources it under the hood to a new diagnostic function. 